### PR TITLE
[v3] Upgrade to Google Mobile Ads SDK 13 + Swift 6 concurrency baseline

### DIFF
--- a/Demo/AdmobSwitUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/AdmobSwitUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "437a992731dc872a39a439f986e7dbc46a18803ae0ab672c9f6384c47f2cd6e6",
+  "originHash" : "1c03c682799f6f75166f026e7bc168324ac5defbfde650e644dec0b7599ba6d2",
   "pins" : [
     {
       "identity" : "swift-package-manager-google-mobile-ads",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "2c121260b1cc690134bdac36cefd330f48cda3f5",
-        "version" : "12.9.0"
+        "revision" : "166a2dcff33c893b22e4bfccbbdd0ed00a248c24",
+        "version" : "13.5.0"
       }
     },
     {

--- a/Demo/AdmobSwitUIDemo/ContentView.swift
+++ b/Demo/AdmobSwitUIDemo/ContentView.swift
@@ -68,8 +68,10 @@ struct ContentView: View {
                     hiddenNative.toggle()
                 }
                 
+                // SDK 13 large anchored adaptive banner is 50-150pt tall
+                // (116pt at iPhone width); 50pt would clip it.
                 BannerView()
-                    .frame(height: 50)
+                    .frame(height: 120)
                     .background(Color.red)
                 
                 if !hiddenNative {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "75452e0977cb3c2f11e964e01cd639dac42202bc251ed4dee5233e4fcac4eb9d",
   "pins" : [
     {
       "identity" : "swift-package-manager-google-mobile-ads",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "2c121260b1cc690134bdac36cefd330f48cda3f5",
-        "version" : "12.9.0"
+        "revision" : "166a2dcff33c893b22e4bfccbbdd0ed00a248c24",
+        "version" : "13.5.0"
       }
     },
     {
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,21 +6,16 @@ import PackageDescription
 let package = Package(
     name: "AdmobSwiftUI",
     defaultLocalization: "en",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v15)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "AdmobSwiftUI",
             targets: ["AdmobSwiftUI"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "12.9.0"),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "13.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "AdmobSwiftUI",
             dependencies: [
@@ -28,9 +23,19 @@ let package = Package(
             ],
             resources: [
                 .process("Resources")
+            ],
+            swiftSettings: [
+                // Stay on Swift 5 mode for now: surface strict-concurrency issues as
+                // warnings first; the switch to Swift 6 mode lands with the test rebuild.
+                .swiftLanguageMode(.v5),
+                .enableUpcomingFeature("StrictConcurrency"),
             ]),
         .testTarget(
             name: "AdmobSwiftUITests",
-            dependencies: ["AdmobSwiftUI"]),
+            dependencies: ["AdmobSwiftUI"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5),
+                .enableUpcomingFeature("StrictConcurrency"),
+            ]),
     ]
 )

--- a/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
+++ b/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
@@ -240,14 +240,29 @@ public enum AdmobSwiftUILogLevel: Int {
 
 // MARK: - Logging Helper
 extension AdmobSwiftUI {
-    /// Current log level (default: .error for release, .debug for debug)
-    public static var logLevel: AdmobSwiftUILogLevel = {
+    private static let logLevelLock = NSLock()
+    // Guarded by logLevelLock; accessed via the thread-safe `logLevel` property below.
+    nonisolated(unsafe) private static var _logLevel: AdmobSwiftUILogLevel = {
         #if DEBUG
         return .debug
         #else
         return .error
         #endif
     }()
+
+    /// Current log level (default: .error for release, .debug for debug)
+    public static var logLevel: AdmobSwiftUILogLevel {
+        get {
+            logLevelLock.lock()
+            defer { logLevelLock.unlock() }
+            return _logLevel
+        }
+        set {
+            logLevelLock.lock()
+            defer { logLevelLock.unlock() }
+            _logLevel = newValue
+        }
+    }
     
     /// Internal logging method
     internal static func log(_ message: String, level: AdmobSwiftUILogLevel = .info) {

--- a/Sources/AdmobSwiftUI/Banner/BannerView.swift
+++ b/Sources/AdmobSwiftUI/Banner/BannerView.swift
@@ -46,7 +46,8 @@ public struct BannerView: UIViewControllerRepresentable {
         // Only reload if size actually changed
         let newAdSize: AdSize = switch style {
         case .anchored:
-            currentOrientationAnchoredAdaptiveBanner(width: viewWidth)
+            // SDK 13: large anchored adaptive banner (50-150pt tall, supports video demand)
+            largeAnchoredAdaptiveBanner(width: viewWidth)
         case .inline:
             currentOrientationInlineAdaptiveBanner(width: viewWidth)
         }
@@ -61,6 +62,7 @@ public struct BannerView: UIViewControllerRepresentable {
         }
     }
 
+    @MainActor
     public class Coordinator: NSObject, BannerViewControllerWidthDelegate, GoogleMobileAds.BannerViewDelegate {
         let bannerView = GoogleMobileAds.BannerView()
         var parent: BannerView
@@ -68,12 +70,12 @@ public struct BannerView: UIViewControllerRepresentable {
         init(_ parent: BannerView) {
             self.parent = parent
         }
-        
+
         // MARK: - BannerViewControllerWidthDelegate methods
-        
+
         func bannerViewController(_ bannerViewController: BannerViewController, didUpdate width: CGFloat) {
-            // Pass the viewWidth from Coordinator to BannerView.
-            DispatchQueue.main.async {
+            // Defer the state mutation out of the current view update cycle.
+            Task { @MainActor in
                 self.parent.viewWidth = width
             }
         }

--- a/Sources/AdmobSwiftUI/Banner/BannerViewController.swift
+++ b/Sources/AdmobSwiftUI/Banner/BannerViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 // Delegate methods for receiving width update messages.
 
+@MainActor
 protocol BannerViewControllerWidthDelegate: AnyObject {
     func bannerViewController(_ bannerViewController: BannerViewController, didUpdate width: CGFloat)
 }

--- a/Sources/AdmobSwiftUI/Extensions/UIView+Extensions.swift
+++ b/Sources/AdmobSwiftUI/Extensions/UIView+Extensions.swift
@@ -75,6 +75,7 @@ extension UIButton {
 }
 
 // MARK: - Stack View Helper Functions
+@MainActor
 func stack(_ views: UIView..., axis: NSLayoutConstraint.Axis = .vertical, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .fill, distribution: UIStackView.Distribution = .fill) -> UIStackView {
     let stackView = UIStackView(arrangedSubviews: views)
     stackView.axis = axis
@@ -85,11 +86,13 @@ func stack(_ views: UIView..., axis: NSLayoutConstraint.Axis = .vertical, spacin
     return stackView
 }
 
+@MainActor
 func hstack(_ views: UIView..., spacing: CGFloat = 0, alignment: UIStackView.Alignment = .fill, distribution: UIStackView.Distribution = .fill) -> UIStackView {
     return hstack(views, spacing: spacing, alignment: alignment, distribution: distribution)
 }
 
 // Handle multiple views for hstack
+@MainActor
 func hstack(_ views: [UIView], spacing: CGFloat = 0, alignment: UIStackView.Alignment = .fill, distribution: UIStackView.Distribution = .fill) -> UIStackView {
     let stackView = UIStackView(arrangedSubviews: views)
     stackView.axis = .horizontal

--- a/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
@@ -5,10 +5,11 @@
 //  Created by minghui on 2023/6/13.
 //
 
-import GoogleMobileAds
+@preconcurrency import GoogleMobileAds
 import SwiftUI
 import UIKit
 
+@MainActor
 public class AppOpenAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
     private var appOpenAd: GoogleMobileAds.AppOpenAd?
     private let adUnitID: String
@@ -31,15 +32,16 @@ public class AppOpenAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDe
     // MARK: - Ad Loading
     public func loadAd() {
         clean()
-        GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-            if let ad = ad {
+        Task {
+            do {
+                let ad = try await GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request())
                 self.appOpenAd = ad
                 self.loadTime = Date()
                 ad.fullScreenContentDelegate = self
-            } else {
-                AdmobSwiftUI.log("Failed to load app open ad: \(error?.localizedDescription ?? "Unknown error")", level: .error)
+            } catch {
+                AdmobSwiftUI.log("Failed to load app open ad: \(error.localizedDescription)", level: .error)
             }
-        })
+        }
     }
     
     // MARK: - Async Ad Loading
@@ -52,18 +54,11 @@ public class AppOpenAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDe
     // MARK: - Async/await API
     public func loadAppOpenAd() async throws -> GoogleMobileAds.AppOpenAd {
         clean()
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let ad = ad {
-                    self.loadTime = Date()
-                    ad.fullScreenContentDelegate = self
-                    continuation.resume(returning: ad)
-                }
-            })
-        }
+
+        let ad = try await GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+        loadTime = Date()
+        ad.fullScreenContentDelegate = self
+        return ad
     }
     
     // MARK: - Ad Presentation

--- a/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
@@ -5,9 +5,10 @@
 //  Created by minghui on 2023/6/13.
 //
 
-import GoogleMobileAds
+@preconcurrency import GoogleMobileAds
 import SwiftUI
 
+@MainActor
 public class InterstitialAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
     private var interstitial: GoogleMobileAds.InterstitialAd?
     private let adUnitID: String
@@ -19,18 +20,16 @@ public class InterstitialAdCoordinator: NSObject, GoogleMobileAds.FullScreenCont
     
     public func loadAd() {
         clean()
-        GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-            if let error = error {
-                AdmobSwiftUI.log("Failed to load interstitial ad: \(error.localizedDescription)", level: .error)
-                return
-            }
-            
-            if let ad = ad {
+        Task {
+            do {
+                let ad = try await GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request())
                 self.interstitial = ad
                 ad.fullScreenContentDelegate = self
                 AdmobSwiftUI.log("Interstitial ad loaded successfully", level: .debug)
+            } catch {
+                AdmobSwiftUI.log("Failed to load interstitial ad: \(error.localizedDescription)", level: .error)
             }
-        })
+        }
     }
     
     public func showAd(from viewController: UIViewController) throws {
@@ -44,17 +43,10 @@ public class InterstitialAdCoordinator: NSObject, GoogleMobileAds.FullScreenCont
     // MARK: - Async/await
     public func loadInterstitialAd() async throws -> GoogleMobileAds.InterstitialAd {
         clean()
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let ad = ad {
-                    ad.fullScreenContentDelegate = self
-                    continuation.resume(returning: ad)
-                }
-            })
-        }
+
+        let ad = try await GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+        ad.fullScreenContentDelegate = self
+        return ad
     }
     
     

--- a/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
@@ -6,8 +6,9 @@
 //
 
 import SwiftUI
-import GoogleMobileAds
+@preconcurrency import GoogleMobileAds
 
+@MainActor
 public class RewardedAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
     private var rewardedInterstitialAd: GoogleMobileAds.RewardedInterstitialAd?
     private var rewardedAd: GoogleMobileAds.RewardedAd?
@@ -21,40 +22,31 @@ public class RewardedAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentD
     
     public func loadAd() {
         clean()
-        GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-            self.rewardedAd = ad
-            self.rewardedAd?.fullScreenContentDelegate = self
-        })
+        Task {
+            do {
+                let ad = try await GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+                self.rewardedAd = ad
+                ad.fullScreenContentDelegate = self
+            } catch {
+                AdmobSwiftUI.log("Failed to load rewarded ad: \(error.localizedDescription)", level: .error)
+            }
+        }
     }
     
     // MARK: - async/await
     
     public func loadInterstitialAd() async throws -> GoogleMobileAds.RewardedInterstitialAd {
         clean()
-        return try await withCheckedThrowingContinuation { continuation in
-            GoogleMobileAds.RewardedInterstitialAd.load(with: InterstitialID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let ad = ad {
-                    ad.fullScreenContentDelegate = self
-                    continuation.resume(returning: ad)
-                }
-            })
-        }
+        let ad = try await GoogleMobileAds.RewardedInterstitialAd.load(with: InterstitialID, request: GoogleMobileAds.Request())
+        ad.fullScreenContentDelegate = self
+        return ad
     }
 
     public func loadRewardedAd() async throws -> GoogleMobileAds.RewardedAd {
         clean()
-        return try await withCheckedThrowingContinuation { continuation in
-            GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request(), completionHandler: { ad, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let ad = ad {
-                    ad.fullScreenContentDelegate = self
-                    continuation.resume(returning: ad)
-                }
-            })
-        }
+        let ad = try await GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+        ad.fullScreenContentDelegate = self
+        return ad
     }
     
     private func clean() {

--- a/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import GoogleMobileAds
 
+@MainActor
 public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.NativeAdLoaderDelegate {
     @Published public var nativeAd: GoogleMobileAds.NativeAd?
     @Published public var isLoading: Bool = false
@@ -15,21 +16,18 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
     private var adUnitID: String
     private var lastRequestTime: Date?
     public var requestInterval: Int
-    private static let cacheQueue = DispatchQueue(label: "com.admobswiftui.native.cache", attributes: .concurrent)
     private static let maxCacheSize = AdmobSwiftUI.Constants.nativeAdCacheMaxSize
+    // Cache is isolated to the main actor along with the rest of the class.
     private static var cachedAds: [String: GoogleMobileAds.NativeAd] = [:]
     private static var lastRequestTimes: [String: Date] = [:]
-    
+
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.native, requestInterval: Int = 1 * 60) {
         self.adUnitID = adUnitID
         self.requestInterval = requestInterval
         super.init()
-        
-        // Get cached ad safely
-        NativeAdViewModel.cacheQueue.sync {
-            self.nativeAd = NativeAdViewModel.cachedAds[adUnitID]
-            self.lastRequestTime = NativeAdViewModel.lastRequestTimes[adUnitID]
-        }
+
+        self.nativeAd = NativeAdViewModel.cachedAds[adUnitID]
+        self.lastRequestTime = NativeAdViewModel.lastRequestTimes[adUnitID]
     }
     
     public func refreshAd() {
@@ -47,10 +45,8 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
 
         isLoading = true
         lastRequestTime = now
-        NativeAdViewModel.cacheQueue.async(flags: .barrier) {
-            NativeAdViewModel.lastRequestTimes[self.adUnitID] = now
-        }
-        
+        NativeAdViewModel.lastRequestTimes[adUnitID] = now
+
         let adViewOptions = GoogleMobileAds.NativeAdViewAdOptions()
         adViewOptions.preferredAdChoicesPosition = .topRightCorner
         adLoader = GoogleMobileAds.AdLoader(adUnitID: adUnitID, rootViewController: nil, adTypes: [.native], options: [adViewOptions])
@@ -75,13 +71,11 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
     
     // MARK: - Cache Management
     private static func setCachedAd(_ ad: GoogleMobileAds.NativeAd, for key: String) {
-        cacheQueue.async(flags: .barrier) {
-            // Clean cache if it's getting too large
-            cleanupCacheIfNeeded()
-            
-            cachedAds[key] = ad
-            lastRequestTimes[key] = Date()
-        }
+        // Clean cache if it's getting too large
+        cleanupCacheIfNeeded()
+
+        cachedAds[key] = ad
+        lastRequestTimes[key] = Date()
     }
     
     private static func cleanupCacheIfNeeded() {

--- a/Sources/AdmobSwiftUI/Native/NativeAdViewStyle.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdViewStyle.swift
@@ -14,6 +14,7 @@ public enum NativeAdViewStyle {
     case banner
     case largeBanner
     
+    @MainActor
     var view: GoogleMobileAds.NativeAdView {
         switch self {
         case .basic:
@@ -27,6 +28,7 @@ public enum NativeAdViewStyle {
         }
     }
     
+    @MainActor
     func makeNibView(name: String) -> GoogleMobileAds.NativeAdView {
         let bundle = Bundle.module
         let nib = UINib(nibName: name, bundle: bundle)

--- a/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
+++ b/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
@@ -83,6 +83,7 @@ final class AdUnitIDsTests: XCTestCase {
     }
 }
 
+@MainActor
 final class CoordinatorInitializationTests: XCTestCase {
 
     func testInterstitialAdCoordinatorDefaultInit() throws {
@@ -112,6 +113,7 @@ final class CoordinatorInitializationTests: XCTestCase {
     }
 }
 
+@MainActor
 final class NativeAdViewModelTests: XCTestCase {
 
     func testNativeAdViewModelInitialization() throws {
@@ -130,6 +132,7 @@ final class NativeAdViewModelTests: XCTestCase {
     }
 }
 
+@MainActor
 final class UIViewExtensionsTests: XCTestCase {
 
     func testHstackVariadicIncludesAllViews() throws {
@@ -176,6 +179,7 @@ final class UIViewExtensionsTests: XCTestCase {
     }
 }
 
+@MainActor
 final class NativeAdViewStyleTests: XCTestCase {
 
     func testAllStylesProduceNativeAdView() throws {


### PR DESCRIPTION
Closes #11（v3.0 milestone 第一個 PR，base 為長分支 `release/3.0`）

## 變更內容

### SDK 升級
- Google Mobile Ads SDK 12.9.0 → **13.5.0**（`from: "13.0.0"`）
- platforms 升至 `.iOS(.v15)`；Demo deployment target 原本就是 16.4，不需調整
- `swift-tools-version: 6.0`，語言模式留 **Swift 5** + `StrictConcurrency` upcoming feature（先 warning、正式切 Swift 6 mode 留給測試重建 issue）

### Banner API 遷移
- `currentOrientationAnchoredAdaptiveBanner(width:)` → `largeAnchoredAdaptiveBanner(width:)`（SDK 13 棄用前者）
- ⚠️ 行為改變（migration guide 素材）：large 變體高度 **50–150pt**（舊版 50–90pt），iPhone 寬度實測為 **116pt**，且可服務 video demand。Demo 的 banner 容器從 50pt 調到 120pt，否則會裁切

### 不需要改的項目
- `GADMaxAdContentRating`：SDK 13 headers 中此 typedef 無 `NS_SWIFT_NAME`，Swift 匯入名稱不變，現有程式碼已是現行命名

### Concurrency 基線（不改公開簽名）
- 三個 fullscreen coordinator、`BannerView.Coordinator`、`NativeAdViewModel` 標 `@MainActor`（與 SDK 13 delegate 方法的 `NS_SWIFT_UI_ACTOR` 標註對齊）
- async 載入改用 SDK 自動生成的 async API，移除手寫 continuation（順帶修掉 ad/error 皆 nil 時 continuation 永不 resume 的潛在懸掛）
- callback 版 `loadAd()` 內部改 `Task` + async API
- `AdmobSwiftUI.logLevel` 改為 NSLock 保護的 computed property（簽名不變）
- Native ad cache 改 MainActor 隔離，移除 GCD concurrent queue
- 全套件編譯警告清零（僅剩 SDK 自身 xcframework 的 umbrella header 警告，非本套件可控）

## 驗證

- ✅ `xcodebuild build`（generic iOS Simulator）：成功、本套件零警告
- ✅ `xcodebuild test`（iPhone 17 模擬器）：22 tests 全綠
- ✅ Demo 模擬器實測（iPhone 17）：Banner（large 116pt 無裁切）、Native、Interstitial、Rewarded、App Open 五種廣告全部正常載入與呈現

🤖 Generated with [Claude Code](https://claude.com/claude-code)