### PR TITLE
[v3] Unify fullscreen coordinator API (async/await + @MainActor)

### DIFF
--- a/Demo/AdmobSwitUIDemo/ContentView.swift
+++ b/Demo/AdmobSwitUIDemo/ContentView.swift
@@ -9,89 +9,182 @@ import SwiftUI
 import AdmobSwiftUI
 
 struct ContentView: View {
+    @Environment(\.scenePhase) private var scenePhase
+
     // 使用預設的 Google 測試廣告 ID
     @StateObject private var nativeViewModel = NativeAdViewModel(requestInterval: 60)
     private let adViewControllerRepresentable = AdViewControllerRepresentable()
-    private let adCoordinator = InterstitialAdCoordinator()
-    private let rewardCoordinator = RewardedAdCoordinator()
-    private let appOpenAdCoordinator = AppOpenAdCoordinator()
-    
+    @StateObject private var adCoordinator = InterstitialAdCoordinator()
+    @StateObject private var rewardCoordinator = RewardedAdCoordinator()
+    @StateObject private var appOpenAdCoordinator = AppOpenAdCoordinator()
+
     @State private var hiddenNative = false
-    
+    @State private var lastReward: AdReward?
+
     var body: some View {
-        ScrollView {
-            VStack (spacing: 20) {
-                Button("Show InterstitialAd") {
-                    Task {
-                        do {
-                            let ad = try await adCoordinator.loadInterstitialAd()
-                            ad.present(from: adViewControllerRepresentable.viewController)
-                        } catch {
-                            print(error.localizedDescription)
-                        }
-                    }
-                }
-                
-                Button("show reward") {
-                    Task {
-                        do {
-                            let reward = try await rewardCoordinator.loadRewardedAd()
-                            reward.present(from: adViewControllerRepresentable.viewController) {
-                                print("Reward amount: \(reward.adReward.amount)")
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    Button("Show InterstitialAd") {
+                        Task {
+                            do {
+                                try await adCoordinator.loadAndPresent(from: adViewControllerRepresentable.viewController)
+                            } catch {
+                                print(error.localizedDescription)
                             }
-                        } catch {
-                            print(error.localizedDescription)
                         }
                     }
-                }
-                
-                Button("Show App Open") {
-                    Task {
-                        do {
-                            let ad = try await appOpenAdCoordinator.loadAppOpenAd()
-                            ad.present(from: adViewControllerRepresentable.viewController)
-                        } catch {
-                            print(error.localizedDescription)
+
+                    Button("show reward") {
+                        Task {
+                            do {
+                                let reward = try await rewardCoordinator.loadAndPresent(from: adViewControllerRepresentable.viewController)
+                                lastReward = reward
+                                print("Reward amount: \(reward.amount) \(reward.type)")
+                            } catch {
+                                print(error.localizedDescription)
+                            }
                         }
                     }
+
+                    if let lastReward {
+                        Text("Last reward: \(lastReward.amount) \(lastReward.type)")
+                            .font(.footnote)
+                    }
+
+                    Button("Show App Open") {
+                        Task {
+                            do {
+                                try await appOpenAdCoordinator.loadAndPresent(from: adViewControllerRepresentable.viewController)
+                            } catch {
+                                print(error.localizedDescription)
+                            }
+                        }
+                    }
+
+                    // 容忍失敗的場景化 API：沒廣告時只記 log 並補載
+                    Button("Present App Open If Available") {
+                        appOpenAdCoordinator.presentIfAvailable()
+                    }
+
+                    Button("reload native") {
+                        Task {
+                            try? await nativeViewModel.load()
+                        }
+                    }
+
+                    Button("show ad config") {
+                        AdmobSwiftUI.AdUnitIDs.printCurrentConfiguration()
+                    }
+
+                    Button("hidden native") {
+                        hiddenNative.toggle()
+                    }
+
+                    NavigationLink("Legacy v2 API (deprecated)") {
+                        LegacyAPIView()
+                    }
+
+                    // SDK 13 large anchored adaptive banner is 50-150pt tall
+                    // (116pt at iPhone width); 50pt would clip it.
+                    BannerView()
+                        .frame(height: 120)
+                        .background(Color.red)
+
+                    if !hiddenNative {
+                        NativeAdView(nativeViewModel: nativeViewModel, style: .banner)
+                            .frame(height: 80)
+                            .background(Color(UIColor.secondarySystemBackground))
+
+//                        NativeAdView(nativeViewModel: nativeViewModel, style: .card)
+//                            .frame(height: 380) // 250 ~ 300
+//                            .background(Color(UIColor.secondarySystemBackground))
+                    }
                 }
-                
-                Button("reload native") {
-                    nativeViewModel.refreshAd()
-                }
-                
-                Button("show ad config") {
-                    AdmobSwiftUI.AdUnitIDs.printCurrentConfiguration()
-                }
-                
-                Button("hidden native") {
-                    hiddenNative.toggle()
-                }
-                
-                // SDK 13 large anchored adaptive banner is 50-150pt tall
-                // (116pt at iPhone width); 50pt would clip it.
-                BannerView()
-                    .frame(height: 120)
-                    .background(Color.red)
-                
-                if !hiddenNative {
-                    NativeAdView(nativeViewModel: nativeViewModel, style: .banner)
-                        .frame(height: 80)
-                        .background(Color(UIColor.secondarySystemBackground))
-                    
-//                    NativeAdView(nativeViewModel: nativeViewModel, style: .card)
-//                        .frame(height: 380) // 250 ~ 300
-//                        .background(Color(UIColor.secondarySystemBackground))
-                }
-                
-                
-                    
+                .padding()
             }
-            .padding()
+            .navigationTitle("AdmobSwiftUI v3")
+            .navigationBarTitleDisplayMode(.inline)
         }
         .background {
             // Add the adViewControllerRepresentable to the background so it
             // doesn't influence the placement of other views in the view hierarchy.
+            adViewControllerRepresentable
+                .frame(width: .zero, height: .zero)
+        }
+        .onAppear {
+            // App open 廣告：前景自動補載，配合 presentIfAvailable 使用
+            appOpenAdCoordinator.autoReloadsOnForeground = true
+            Task {
+                try? await nativeViewModel.load()
+            }
+        }
+        .onChange(of: scenePhase) { phase in
+            if phase == .active {
+                print("App open ad ready: \(appOpenAdCoordinator.isReady)")
+            }
+        }
+    }
+}
+
+/// 用 v2（deprecated）API 的頁面：驗證 3.x shims 只有 deprecation warning、行為照舊。
+struct LegacyAPIView: View {
+    @StateObject private var nativeViewModel = NativeAdViewModel(requestInterval: 60)
+    private let adViewControllerRepresentable = AdViewControllerRepresentable()
+    @StateObject private var adCoordinator = InterstitialAdCoordinator()
+    @StateObject private var rewardCoordinator = RewardedAdCoordinator()
+    @StateObject private var appOpenAdCoordinator = AppOpenAdCoordinator()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Button("Load Interstitial (v2 loadAd)") {
+                adCoordinator.loadAd()
+            }
+
+            Button("Show Interstitial (v2 showAd)") {
+                do {
+                    try adCoordinator.showAd(from: adViewControllerRepresentable.viewController)
+                } catch {
+                    print(error.localizedDescription)
+                }
+            }
+
+            Button("Show Reward (v2 load + showAd)") {
+                Task {
+                    do {
+                        _ = try await rewardCoordinator.loadRewardedAd()
+                        rewardCoordinator.showAd(from: adViewControllerRepresentable.viewController) { amount in
+                            print("Reward amount: \(amount)")
+                        }
+                    } catch {
+                        print(error.localizedDescription)
+                    }
+                }
+            }
+
+            Button("Show App Open (v2 loadAppOpenAd)") {
+                Task {
+                    do {
+                        let ad = try await appOpenAdCoordinator.loadAppOpenAd()
+                        ad.present(from: adViewControllerRepresentable.viewController)
+                    } catch {
+                        print(error.localizedDescription)
+                    }
+                }
+            }
+
+            Button("Reload Native (v2 refreshAd)") {
+                nativeViewModel.refreshAd()
+            }
+
+            NativeAdView(nativeViewModel: nativeViewModel, style: .banner)
+                .frame(height: 80)
+                .background(Color(UIColor.secondarySystemBackground))
+        }
+        .padding()
+        .navigationTitle("Legacy v2 API")
+        .navigationBarTitleDisplayMode(.inline)
+        .background {
             adViewControllerRepresentable
                 .frame(width: .zero, height: .zero)
         }

--- a/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
+++ b/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
@@ -8,12 +8,14 @@ public struct AdmobSwiftUI {
     /// Package version
     public static let version = "2.1.0"
 
-    /// Internal constants shared across the package
-    enum Constants {
+    /// Constants shared across the package
+    public enum Constants {
         /// App Open ads expire after 4 hours (Google policy)
-        static let appOpenAdExpirationInterval: TimeInterval = 4 * 60 * 60
+        public static let appOpenAdExpirationInterval: TimeInterval = 4 * 60 * 60
         /// Maximum number of native ads kept in the in-memory cache
-        static let nativeAdCacheMaxSize = 10
+        public static let nativeAdCacheMaxSize = 10
+        /// Default minimum interval (seconds) between native ad requests
+        public static let nativeAdDefaultRequestInterval = 60
     }
     
     /// Configuration for AdMob initialization
@@ -210,6 +212,7 @@ public enum AdmobSwiftUIError: Error, LocalizedError {
     case sdkNotInitialized
     case adExpired
     case invalidConfiguration(String)
+    case rewardNotEarned
     
     public var errorDescription: String? {
         switch self {
@@ -225,6 +228,8 @@ public enum AdmobSwiftUIError: Error, LocalizedError {
             return "The loaded ad has expired and cannot be shown"
         case .invalidConfiguration(let message):
             return "Invalid configuration: \(message)"
+        case .rewardNotEarned:
+            return "The rewarded ad was dismissed before the reward was earned"
         }
     }
 }

--- a/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
@@ -1,6 +1,6 @@
 //
 //  AppOpenAdCoordinator.swift
-//  
+//
 //
 //  Created by minghui on 2023/6/13.
 //
@@ -10,146 +10,214 @@ import SwiftUI
 import UIKit
 
 @MainActor
-public class AppOpenAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
+public final class AppOpenAdCoordinator: NSObject, ObservableObject, FullScreenAdCoordinator {
+    @Published public private(set) var adState: AdState = .idle
+
+    /// When enabled, the coordinator automatically reloads an ad after the
+    /// presented one is dismissed and whenever the app returns to the
+    /// foreground without a usable ad — replacing the hand-written
+    /// scenePhase reload boilerplate. Pair it with ``presentIfAvailable(from:)``.
+    public var autoReloadsOnForeground: Bool = false {
+        didSet { updateForegroundObserver() }
+    }
+
     private var appOpenAd: GoogleMobileAds.AppOpenAd?
     private let adUnitID: String
     private var loadTime: Date?
-    
+    private var foregroundObserver: (any NSObjectProtocol)?
+
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.appOpen) {
         // Validate ad unit ID
         guard !adUnitID.isEmpty else {
             fatalError("AdmobSwiftUI: Ad unit ID cannot be empty")
         }
-        
+
         if adUnitID.hasPrefix("your-") {
             AdmobSwiftUI.log("Warning: Using placeholder ad unit ID. Replace with your actual ad unit ID before release.", level: .warning)
         }
-        
+
         self.adUnitID = adUnitID
         super.init()
     }
-    
-    // MARK: - Ad Loading
-    public func loadAd() {
-        clean()
-        Task {
-            do {
-                let ad = try await GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-                self.appOpenAd = ad
-                self.loadTime = Date()
-                ad.fullScreenContentDelegate = self
-            } catch {
-                AdmobSwiftUI.log("Failed to load app open ad: \(error.localizedDescription)", level: .error)
-            }
+
+    deinit {
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
         }
     }
-    
-    // MARK: - Async Ad Loading
-    public typealias AdType = GoogleMobileAds.AppOpenAd
-    
-    public func loadAdAsync() async throws -> GoogleMobileAds.AppOpenAd {
-        return try await loadAppOpenAd()
-    }
-    
-    // MARK: - Async/await API
-    public func loadAppOpenAd() async throws -> GoogleMobileAds.AppOpenAd {
-        clean()
 
-        let ad = try await GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-        loadTime = Date()
-        ad.fullScreenContentDelegate = self
-        return ad
+    // MARK: - FullScreenAdCoordinator
+
+    public var isReady: Bool {
+        adState == .ready && !isAdExpired
     }
-    
-    // MARK: - Ad Presentation
-    public func showAd(from viewController: UIViewController) throws {
-        guard let appOpenAd = appOpenAd else {
+
+    public func load() async throws {
+        guard adState != .loading else {
+            AdmobSwiftUI.log("App open ad is already loading, request ignored", level: .debug)
+            return
+        }
+        clean()
+        adState = .loading
+        do {
+            let ad = try await GoogleMobileAds.AppOpenAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+            ad.fullScreenContentDelegate = self
+            appOpenAd = ad
+            loadTime = Date()
+            adState = .ready
+            AdmobSwiftUI.log("App open ad loaded successfully", level: .debug)
+        } catch {
+            adState = .idle
+            AdmobSwiftUI.log("Failed to load app open ad: \(error.localizedDescription)", level: .error)
+            throw AdmobSwiftUIError.adLoadFailed(error)
+        }
+    }
+
+    public func present(from viewController: UIViewController) throws {
+        guard let appOpenAd else {
             throw AdmobSwiftUIError.adNotLoaded
         }
-        
         guard !isAdExpired else {
+            clean()
             throw AdmobSwiftUIError.adExpired
         }
-        
+        adState = .presenting
         appOpenAd.present(from: viewController)
     }
-    
-    // MARK: - Ad State Management
-    public var isAdAvailable: Bool {
-        return appOpenAd != nil && !isAdExpired
+
+    /// Failure-tolerant presentation for scene-phase call sites: presents the
+    /// ad if one is ready, otherwise just logs and (when nothing is in flight)
+    /// kicks off a reload so the next foreground transition has an ad.
+    /// - Parameter viewController: Presenting view controller; pass `nil` to
+    ///   let the SDK present from the key window's root view controller.
+    public func presentIfAvailable(from viewController: UIViewController? = nil) {
+        guard isReady, let appOpenAd else {
+            AdmobSwiftUI.log("App open ad not ready to present (state: \(adState))", level: .debug)
+            if adState == .idle || (adState == .ready && isAdExpired) {
+                reload()
+            }
+            return
+        }
+        adState = .presenting
+        appOpenAd.present(from: viewController)
     }
-    
+
+    // MARK: - Private
+
     private var isAdExpired: Bool {
-        guard let loadTime = loadTime else { return true }
+        guard let loadTime else { return true }
         return Date().timeIntervalSince(loadTime) > AdmobSwiftUI.Constants.appOpenAdExpirationInterval
     }
-    
+
     private func clean() {
         appOpenAd?.fullScreenContentDelegate = nil
         appOpenAd = nil
         loadTime = nil
-    }
-    
-    // MARK: - GADFullScreenContentDelegate methods
-    public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
-        clean()
-    }
-    
-    public func ad(_ ad: GoogleMobileAds.FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        AdmobSwiftUI.log("Failed to present app open ad: \(error.localizedDescription)", level: .error)
-        clean()
+        adState = .idle
     }
 
-    public func adWillPresentFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
+    private func reload() {
+        Task { try? await load() }
+    }
+
+    private func updateForegroundObserver() {
+        if autoReloadsOnForeground, foregroundObserver == nil {
+            foregroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self, self.autoReloadsOnForeground, !self.isReady, self.adState == .idle else { return }
+                    self.reload()
+                }
+            }
+        } else if !autoReloadsOnForeground, let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+            foregroundObserver = nil
+        }
+    }
+}
+
+// MARK: - GADFullScreenContentDelegate
+// SDK callbacks are not guaranteed to arrive on the main thread,
+// so conform with nonisolated methods and hop back to the main actor.
+extension AppOpenAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
+    nonisolated public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
+        Task { @MainActor in
+            self.clean()
+            if self.autoReloadsOnForeground {
+                self.reload()
+            }
+        }
+    }
+
+    nonisolated public func ad(_ ad: GoogleMobileAds.FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        let message = error.localizedDescription
+        Task { @MainActor in
+            AdmobSwiftUI.log("Failed to present app open ad: \(message)", level: .error)
+            self.clean()
+        }
+    }
+
+    nonisolated public func adWillPresentFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
         AdmobSwiftUI.log("App open ad will present", level: .debug)
     }
 
-    public func adDidRecordImpression(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
+    nonisolated public func adDidRecordImpression(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
         AdmobSwiftUI.log("App open ad did record impression", level: .debug)
+    }
+}
+
+// MARK: - Deprecated v2 API (will be removed in 4.0)
+extension AppOpenAdCoordinator {
+    @available(*, deprecated, renamed: "isReady", message: "Use `isReady` instead. Will be removed in 4.0.")
+    public var isAdAvailable: Bool {
+        isReady
+    }
+
+    @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
+    public func loadAd() {
+        Task { try? await load() }
+    }
+
+    @available(*, deprecated, renamed: "present(from:)", message: "Use `present(from:)` or `presentIfAvailable(from:)` instead. Will be removed in 4.0.")
+    public func showAd(from viewController: UIViewController) throws {
+        try present(from: viewController)
+    }
+
+    @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
+    public func loadAppOpenAd() async throws -> GoogleMobileAds.AppOpenAd {
+        try await load()
+        guard let ad = appOpenAd else {
+            throw AdmobSwiftUIError.adNotLoaded
+        }
+        return ad
+    }
+
+    @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
+    public func loadAdAsync() async throws -> GoogleMobileAds.AppOpenAd {
+        try await loadAppOpenAd()
     }
 }
 
 // MARK: - Usage Example
 /*
 struct ContentView: View {
-    private let adViewControllerRepresentable = AdViewControllerRepresentable()
-    private let appOpenAdCoordinator = AppOpenAdCoordinator()
-    
-    var body: some View {
-        VStack {
-            Text("App Content")
-            
-            Button("Load App Open Ad") {
-                appOpenAdCoordinator.loadAd()
-            }
-            
-            Button("Show App Open Ad") {
-                appOpenAdCoordinator.showAd(from: adViewControllerRepresentable.viewController)
-            }
-        }
-        .background {
-            // Add the adViewControllerRepresentable to the background
-            adViewControllerRepresentable
-                .frame(width: .zero, height: .zero)
-        }
-        .onAppear {
-            // Typically load app open ad when app becomes active
-            appOpenAdCoordinator.loadAd()
-        }
-    }
-}
+    @Environment(\.scenePhase) private var scenePhase
+    @StateObject private var appOpenAdCoordinator = AppOpenAdCoordinator()
 
-// For app lifecycle management
-class AppDelegate: UIResponder, UIApplicationDelegate {
-    let appOpenAdCoordinator = AppOpenAdCoordinator()
-    
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Show app open ad when app becomes active
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first,
-           let rootViewController = window.rootViewController {
-            appOpenAdCoordinator.showAd(from: rootViewController)
-        }
+    var body: some View {
+        Text("App Content")
+            .onAppear {
+                appOpenAdCoordinator.autoReloadsOnForeground = true
+            }
+            .onChange(of: scenePhase) { phase in
+                if phase == .active {
+                    // Tolerates "no ad yet" — presents when ready, reloads otherwise.
+                    appOpenAdCoordinator.presentIfAvailable()
+                }
+            }
     }
 }
 */

--- a/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
@@ -1,6 +1,6 @@
 //
 //  InterstitialAdCoordinator.swift
-//  
+//
 //
 //  Created by minghui on 2023/6/13.
 //
@@ -9,55 +9,94 @@
 import SwiftUI
 
 @MainActor
-public class InterstitialAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
+public final class InterstitialAdCoordinator: NSObject, ObservableObject, FullScreenAdCoordinator {
+    @Published public private(set) var adState: AdState = .idle
+
     private var interstitial: GoogleMobileAds.InterstitialAd?
     private let adUnitID: String
-    
+
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.interstitial) {
         self.adUnitID = adUnitID
         super.init()
     }
-    
-    public func loadAd() {
+
+    // MARK: - FullScreenAdCoordinator
+
+    public func load() async throws {
+        guard adState != .loading else {
+            AdmobSwiftUI.log("Interstitial ad is already loading, request ignored", level: .debug)
+            return
+        }
         clean()
-        Task {
-            do {
-                let ad = try await GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-                self.interstitial = ad
-                ad.fullScreenContentDelegate = self
-                AdmobSwiftUI.log("Interstitial ad loaded successfully", level: .debug)
-            } catch {
-                AdmobSwiftUI.log("Failed to load interstitial ad: \(error.localizedDescription)", level: .error)
-            }
+        adState = .loading
+        do {
+            let ad = try await GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request())
+            ad.fullScreenContentDelegate = self
+            interstitial = ad
+            adState = .ready
+            AdmobSwiftUI.log("Interstitial ad loaded successfully", level: .debug)
+        } catch {
+            adState = .idle
+            AdmobSwiftUI.log("Failed to load interstitial ad: \(error.localizedDescription)", level: .error)
+            throw AdmobSwiftUIError.adLoadFailed(error)
         }
     }
-    
-    public func showAd(from viewController: UIViewController) throws {
-        guard let interstitial = interstitial else {
+
+    public func present(from viewController: UIViewController) throws {
+        guard let interstitial else {
             throw AdmobSwiftUIError.adNotLoaded
         }
-        
+        adState = .presenting
         interstitial.present(from: viewController)
     }
-    
-    // MARK: - Async/await
-    public func loadInterstitialAd() async throws -> GoogleMobileAds.InterstitialAd {
-        clean()
 
-        let ad = try await GoogleMobileAds.InterstitialAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-        ad.fullScreenContentDelegate = self
-        return ad
-    }
-    
-    
+    // MARK: - Private
+
     private func clean() {
         interstitial?.fullScreenContentDelegate = nil
         interstitial = nil
+        adState = .idle
     }
-    
-    // MARK: - GADFullScreenContentDelegate methods
-    public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
-        clean()
+}
+
+// MARK: - GADFullScreenContentDelegate
+// SDK callbacks are not guaranteed to arrive on the main thread,
+// so conform with nonisolated methods and hop back to the main actor.
+extension InterstitialAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
+    nonisolated public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
+        Task { @MainActor in
+            self.clean()
+        }
+    }
+
+    nonisolated public func ad(_ ad: GoogleMobileAds.FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        let message = error.localizedDescription
+        Task { @MainActor in
+            AdmobSwiftUI.log("Failed to present interstitial ad: \(message)", level: .error)
+            self.clean()
+        }
+    }
+}
+
+// MARK: - Deprecated v2 API (will be removed in 4.0)
+extension InterstitialAdCoordinator {
+    @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
+    public func loadAd() {
+        Task { try? await load() }
+    }
+
+    @available(*, deprecated, renamed: "present(from:)", message: "Use `present(from:)` instead. Will be removed in 4.0.")
+    public func showAd(from viewController: UIViewController) throws {
+        try present(from: viewController)
+    }
+
+    @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
+    public func loadInterstitialAd() async throws -> GoogleMobileAds.InterstitialAd {
+        try await load()
+        guard let ad = interstitial else {
+            throw AdmobSwiftUIError.adNotLoaded
+        }
+        return ad
     }
 }
 
@@ -65,48 +104,27 @@ public class InterstitialAdCoordinator: NSObject, GoogleMobileAds.FullScreenCont
 /*
 struct SampleView: View {
     private let adViewControllerRepresentable = AdViewControllerRepresentable()
-    private let interstitialAdCoordinator = InterstitialAdCoordinator()
-    
+    @StateObject private var interstitialAdCoordinator = InterstitialAdCoordinator()
+
     var body: some View {
         VStack {
             Text("Content View")
-            
-            Button("Load Interstitial Ad") {
-                interstitialAdCoordinator.loadAd()
-            }
-            
-            Button("Show Interstitial Ad") {
-                interstitialAdCoordinator.showAd(from: adViewControllerRepresentable.viewController)
-            }
-        }
-        .background {
-            // Add the adViewControllerRepresentable to the background so it
-            // does not influence the placement of other views in the view hierarchy.
-            adViewControllerRepresentable
-                .frame(width: .zero, height: .zero)
-        }
-    }
-}
 
-// Async/await usage example
-struct AsyncSampleView: View {
-    private let adViewControllerRepresentable = AdViewControllerRepresentable()
-    private let interstitialAdCoordinator = InterstitialAdCoordinator()
-    
-    var body: some View {
-        VStack {
-            Button("Load & Show Interstitial Ad") {
+            Button("Show Interstitial Ad") {
                 Task {
                     do {
-                        let ad = try await interstitialAdCoordinator.loadInterstitialAd()
-                        ad.present(fromRootViewController: adViewControllerRepresentable.viewController)
+                        try await interstitialAdCoordinator.loadAndPresent(
+                            from: adViewControllerRepresentable.viewController
+                        )
                     } catch {
-                        print("Failed to load interstitial ad: \(error)")
+                        print("Failed to show interstitial ad: \(error)")
                     }
                 }
             }
         }
         .background {
+            // Add the adViewControllerRepresentable to the background so it
+            // does not influence the placement of other views in the view hierarchy.
             adViewControllerRepresentable
                 .frame(width: .zero, height: .zero)
         }

--- a/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
@@ -1,6 +1,6 @@
 //
 //  RewardedAdCoordinator.swift
-//  
+//
 //
 //  Created by minghui on 2023/6/13.
 //
@@ -8,64 +8,180 @@
 import SwiftUI
 @preconcurrency import GoogleMobileAds
 
+/// Coordinator for rewarded and rewarded interstitial ads.
+///
+/// Follows the same `adState` / `load()` shape as ``FullScreenAdCoordinator``,
+/// but `present(from:)` suspends until the user earns the reward and returns
+/// an ``AdReward`` directly, so it does not conform to the protocol.
 @MainActor
-public class RewardedAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentDelegate {
-    private var rewardedInterstitialAd: GoogleMobileAds.RewardedInterstitialAd?
-    private var rewardedAd: GoogleMobileAds.RewardedAd?
-    private let adUnitID: String
-    private let InterstitialID: String
-    
-    public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.rewarded, InterstitialID: String = AdmobSwiftUI.AdUnitIDs.rewardedInterstitial) {
-        self.adUnitID = adUnitID
-        self.InterstitialID = InterstitialID
+public final class RewardedAdCoordinator: NSObject, ObservableObject {
+
+    /// Which rewarded format to load.
+    public enum AdKind: Sendable {
+        case rewarded
+        case rewardedInterstitial
     }
-    
-    public func loadAd() {
+
+    @Published public private(set) var adState: AdState = .idle
+
+    public var isReady: Bool { adState == .ready }
+
+    private var rewardedAd: GoogleMobileAds.RewardedAd?
+    private var rewardedInterstitialAd: GoogleMobileAds.RewardedInterstitialAd?
+    private let adUnitID: String
+    private let interstitialAdUnitID: String
+    private var rewardContinuation: CheckedContinuation<AdReward, any Error>?
+
+    public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.rewarded,
+                interstitialAdUnitID: String = AdmobSwiftUI.AdUnitIDs.rewardedInterstitial) {
+        self.adUnitID = adUnitID
+        self.interstitialAdUnitID = interstitialAdUnitID
+    }
+
+    // MARK: - Async/await API
+
+    public func load(_ kind: AdKind = .rewarded) async throws {
+        guard adState != .loading else {
+            AdmobSwiftUI.log("Rewarded ad is already loading, request ignored", level: .debug)
+            return
+        }
         clean()
-        Task {
-            do {
+        adState = .loading
+        do {
+            switch kind {
+            case .rewarded:
                 let ad = try await GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-                self.rewardedAd = ad
                 ad.fullScreenContentDelegate = self
-            } catch {
-                AdmobSwiftUI.log("Failed to load rewarded ad: \(error.localizedDescription)", level: .error)
+                rewardedAd = ad
+            case .rewardedInterstitial:
+                let ad = try await GoogleMobileAds.RewardedInterstitialAd.load(with: interstitialAdUnitID, request: GoogleMobileAds.Request())
+                ad.fullScreenContentDelegate = self
+                rewardedInterstitialAd = ad
+            }
+            adState = .ready
+            AdmobSwiftUI.log("Rewarded ad loaded successfully", level: .debug)
+        } catch {
+            adState = .idle
+            AdmobSwiftUI.log("Failed to load rewarded ad: \(error.localizedDescription)", level: .error)
+            throw AdmobSwiftUIError.adLoadFailed(error)
+        }
+    }
+
+    /// Presents the loaded ad and suspends until the user earns the reward.
+    /// - Returns: The earned ``AdReward``.
+    /// - Throws: ``AdmobSwiftUIError/adNotLoaded`` if no ad is ready,
+    ///   ``AdmobSwiftUIError/rewardNotEarned`` if the user dismisses the ad
+    ///   before earning the reward.
+    public func present(from viewController: UIViewController) async throws -> AdReward {
+        guard adState == .ready else {
+            throw AdmobSwiftUIError.adNotLoaded
+        }
+        adState = .presenting
+        return try await withCheckedThrowingContinuation { continuation in
+            rewardContinuation = continuation
+            if let rewardedAd {
+                rewardedAd.present(from: viewController) { [weak self] in
+                    guard let self else { return }
+                    let reward = rewardedAd.adReward
+                    self.resumeReward(.success(AdReward(amount: reward.amount.intValue, type: reward.type)))
+                }
+            } else if let rewardedInterstitialAd {
+                rewardedInterstitialAd.present(from: viewController) { [weak self] in
+                    guard let self else { return }
+                    let reward = rewardedInterstitialAd.adReward
+                    self.resumeReward(.success(AdReward(amount: reward.amount.intValue, type: reward.type)))
+                }
+            } else {
+                resumeReward(.failure(AdmobSwiftUIError.adNotLoaded))
             }
         }
     }
-    
-    // MARK: - async/await
-    
-    public func loadInterstitialAd() async throws -> GoogleMobileAds.RewardedInterstitialAd {
-        clean()
-        let ad = try await GoogleMobileAds.RewardedInterstitialAd.load(with: InterstitialID, request: GoogleMobileAds.Request())
-        ad.fullScreenContentDelegate = self
+
+    /// Loads an ad if needed, presents it, and suspends until the reward is earned.
+    @discardableResult
+    public func loadAndPresent(_ kind: AdKind = .rewarded, from viewController: UIViewController) async throws -> AdReward {
+        if !isReady {
+            try await load(kind)
+        }
+        return try await present(from: viewController)
+    }
+
+    // MARK: - Private
+
+    private func resumeReward(_ result: Result<AdReward, any Error>) {
+        rewardContinuation?.resume(with: result)
+        rewardContinuation = nil
+    }
+
+    private func clean() {
+        // Never leak a suspended caller: if an ad is torn down while a
+        // present(from:) is still pending, fail it explicitly.
+        resumeReward(.failure(AdmobSwiftUIError.rewardNotEarned))
+        rewardedInterstitialAd?.fullScreenContentDelegate = nil
+        rewardedAd?.fullScreenContentDelegate = nil
+        rewardedInterstitialAd = nil
+        rewardedAd = nil
+        adState = .idle
+    }
+}
+
+// MARK: - GADFullScreenContentDelegate
+// SDK callbacks are not guaranteed to arrive on the main thread,
+// so conform with nonisolated methods and hop back to the main actor.
+extension RewardedAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
+    nonisolated public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
+        Task { @MainActor in
+            self.clean()
+        }
+    }
+
+    nonisolated public func ad(_ ad: GoogleMobileAds.FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        let message = error.localizedDescription
+        Task { @MainActor in
+            AdmobSwiftUI.log("Failed to present rewarded ad: \(message)", level: .error)
+            self.resumeReward(.failure(AdmobSwiftUIError.presentationFailed(message)))
+            self.clean()
+        }
+    }
+}
+
+// MARK: - Deprecated v2 API (will be removed in 4.0)
+extension RewardedAdCoordinator {
+    @available(*, deprecated, renamed: "init(adUnitID:interstitialAdUnitID:)", message: "Use `init(adUnitID:interstitialAdUnitID:)` instead. Will be removed in 4.0.")
+    public convenience init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.rewarded, InterstitialID: String) {
+        self.init(adUnitID: adUnitID, interstitialAdUnitID: InterstitialID)
+    }
+
+    @available(*, deprecated, renamed: "load(_:)", message: "Use `try await load()` instead. Will be removed in 4.0.")
+    public func loadAd() {
+        Task { try? await load() }
+    }
+
+    @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
+    public func loadRewardedAd() async throws -> GoogleMobileAds.RewardedAd {
+        try await load(.rewarded)
+        guard let ad = rewardedAd else {
+            throw AdmobSwiftUIError.adNotLoaded
+        }
         return ad
     }
 
-    public func loadRewardedAd() async throws -> GoogleMobileAds.RewardedAd {
-        clean()
-        let ad = try await GoogleMobileAds.RewardedAd.load(with: adUnitID, request: GoogleMobileAds.Request())
-        ad.fullScreenContentDelegate = self
+    @available(*, deprecated, message: "Use `load(.rewardedInterstitial)` and `present(from:)` instead. Will be removed in 4.0.")
+    public func loadInterstitialAd() async throws -> GoogleMobileAds.RewardedInterstitialAd {
+        try await load(.rewardedInterstitial)
+        guard let ad = rewardedInterstitialAd else {
+            throw AdmobSwiftUIError.adNotLoaded
+        }
         return ad
     }
-    
-    private func clean() {
-        rewardedInterstitialAd?.fullScreenContentDelegate = nil
-        rewardedAd?.fullScreenContentDelegate = nil
-        self.rewardedInterstitialAd = nil
-        self.rewardedAd = nil
-    }
-    
-    public func adDidDismissFullScreenContent(_ ad: GoogleMobileAds.FullScreenPresentingAd) {
-        clean()
-    }
-    
+
+    @available(*, deprecated, message: "Use `try await present(from:)` instead. Will be removed in 4.0.")
     public func showAd(from viewController: UIViewController, userDidEarnRewardHandler completion: @escaping (Int) -> Void) {
-        guard let rewardedAd = rewardedAd else {
+        guard let rewardedAd else {
             AdmobSwiftUI.log("Rewarded ad wasn't ready", level: .warning)
             return
         }
-
+        adState = .presenting
         rewardedAd.present(from: viewController, userDidEarnRewardHandler: {
             let reward = rewardedAd.adReward
             AdmobSwiftUI.log("Reward amount: \(reward.amount)", level: .debug)
@@ -73,3 +189,30 @@ public class RewardedAdCoordinator: NSObject, GoogleMobileAds.FullScreenContentD
         })
     }
 }
+
+// MARK: - Usage Example
+/*
+struct RewardSampleView: View {
+    private let adViewControllerRepresentable = AdViewControllerRepresentable()
+    @StateObject private var rewardCoordinator = RewardedAdCoordinator()
+
+    var body: some View {
+        Button("Watch ad to earn reward") {
+            Task {
+                do {
+                    let reward = try await rewardCoordinator.loadAndPresent(
+                        from: adViewControllerRepresentable.viewController
+                    )
+                    print("Earned \(reward.amount) \(reward.type)")
+                } catch {
+                    print("No reward: \(error)")
+                }
+            }
+        }
+        .background {
+            adViewControllerRepresentable
+                .frame(width: .zero, height: .zero)
+        }
+    }
+}
+*/

--- a/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
@@ -1,27 +1,29 @@
 //
 //  SwiftUIView.swift
-//  
+//
 //
 //  Created by minghui on 2023/6/14.
 //
 
 import SwiftUI
-import GoogleMobileAds
+@preconcurrency import GoogleMobileAds
 
 @MainActor
-public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.NativeAdLoaderDelegate {
+public class NativeAdViewModel: NSObject, ObservableObject {
     @Published public var nativeAd: GoogleMobileAds.NativeAd?
     @Published public var isLoading: Bool = false
     private var adLoader: GoogleMobileAds.AdLoader!
     private var adUnitID: String
     private var lastRequestTime: Date?
+    private var loadContinuation: CheckedContinuation<Void, any Error>?
     public var requestInterval: Int
     private static let maxCacheSize = AdmobSwiftUI.Constants.nativeAdCacheMaxSize
     // Cache is isolated to the main actor along with the rest of the class.
     private static var cachedAds: [String: GoogleMobileAds.NativeAd] = [:]
     private static var lastRequestTimes: [String: Date] = [:]
 
-    public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.native, requestInterval: Int = 1 * 60) {
+    public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.native,
+                requestInterval: Int = AdmobSwiftUI.Constants.nativeAdDefaultRequestInterval) {
         self.adUnitID = adUnitID
         self.requestInterval = requestInterval
         super.init()
@@ -29,10 +31,16 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
         self.nativeAd = NativeAdViewModel.cachedAds[adUnitID]
         self.lastRequestTime = NativeAdViewModel.lastRequestTimes[adUnitID]
     }
-    
-    public func refreshAd() {
+
+    /// Loads a native ad and suspends until the request finishes.
+    ///
+    /// Requests made within `requestInterval` of the previous one (while a
+    /// cached ad exists) or while another request is in flight return
+    /// immediately without error.
+    /// - Throws: ``AdmobSwiftUIError/adLoadFailed(_:)`` if the request fails.
+    public func load() async throws {
         let now = Date()
-        
+
         if nativeAd != nil, let lastRequest = lastRequestTime, now.timeIntervalSince(lastRequest) < Double(requestInterval) {
             AdmobSwiftUI.log("The last request was made less than \(requestInterval / 60) minutes ago. New request is canceled.", level: .debug)
             return
@@ -51,24 +59,34 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
         adViewOptions.preferredAdChoicesPosition = .topRightCorner
         adLoader = GoogleMobileAds.AdLoader(adUnitID: adUnitID, rootViewController: nil, adTypes: [.native], options: [adViewOptions])
         adLoader.delegate = self
-        adLoader.load(GoogleMobileAds.Request())
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            loadContinuation = continuation
+            adLoader.load(GoogleMobileAds.Request())
+        }
     }
-    
-    public func adLoader(_ adLoader: GoogleMobileAds.AdLoader, didReceive nativeAd: GoogleMobileAds.NativeAd) {
+
+    // MARK: - Loader result handling (main actor)
+
+    private func handleLoaded(_ nativeAd: GoogleMobileAds.NativeAd) {
         self.nativeAd = nativeAd
         nativeAd.delegate = self
         self.isLoading = false
-        
+
         // Cache the ad safely with size management
         Self.setCachedAd(nativeAd, for: adUnitID)
         nativeAd.mediaContent.videoController.delegate = self
+
+        loadContinuation?.resume()
+        loadContinuation = nil
     }
-    
-    public func adLoader(_ adLoader: GoogleMobileAds.AdLoader, didFailToReceiveAdWithError error: Error) {
-        AdmobSwiftUI.log("\(adLoader) failed with error: \(error.localizedDescription)", level: .error)
+
+    private func handleLoadFailure(_ error: any Error) {
         self.isLoading = false
+        loadContinuation?.resume(throwing: AdmobSwiftUIError.adLoadFailed(error))
+        loadContinuation = nil
     }
-    
+
     // MARK: - Cache Management
     private static func setCachedAd(_ ad: GoogleMobileAds.NativeAd, for key: String) {
         // Clean cache if it's getting too large
@@ -77,10 +95,10 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
         cachedAds[key] = ad
         lastRequestTimes[key] = Date()
     }
-    
+
     private static func cleanupCacheIfNeeded() {
         guard cachedAds.count >= maxCacheSize else { return }
-        
+
         // Remove oldest cached ad
         if let oldestKey = lastRequestTimes.min(by: { $0.value < $1.value })?.key {
             cachedAds.removeValue(forKey: oldestKey)
@@ -89,29 +107,55 @@ public class NativeAdViewModel: NSObject, ObservableObject, GoogleMobileAds.Nati
     }
 }
 
+// MARK: - Deprecated v2 API (will be removed in 4.0)
+extension NativeAdViewModel {
+    @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
+    public func refreshAd() {
+        Task { try? await load() }
+    }
+}
+
+// MARK: - GADNativeAdLoaderDelegate
+// SDK callbacks are not guaranteed to arrive on the main thread,
+// so conform with nonisolated methods and hop back to the main actor.
+extension NativeAdViewModel: GoogleMobileAds.NativeAdLoaderDelegate {
+    nonisolated public func adLoader(_ adLoader: GoogleMobileAds.AdLoader, didReceive nativeAd: GoogleMobileAds.NativeAd) {
+        Task { @MainActor in
+            self.handleLoaded(nativeAd)
+        }
+    }
+
+    nonisolated public func adLoader(_ adLoader: GoogleMobileAds.AdLoader, didFailToReceiveAdWithError error: any Error) {
+        AdmobSwiftUI.log("Ad loader failed with error: \(error.localizedDescription)", level: .error)
+        Task { @MainActor in
+            self.handleLoadFailure(error)
+        }
+    }
+}
+
 extension NativeAdViewModel: GoogleMobileAds.VideoControllerDelegate {
     // GADVideoControllerDelegate methods
-    public func videoControllerDidPlayVideo(_ videoController: GoogleMobileAds.VideoController) {
+    nonisolated public func videoControllerDidPlayVideo(_ videoController: GoogleMobileAds.VideoController) {
         // Implement this method to receive a notification when the video controller
         // begins playing the ad.
     }
-    
-    public func videoControllerDidPauseVideo(_ videoController: GoogleMobileAds.VideoController) {
+
+    nonisolated public func videoControllerDidPauseVideo(_ videoController: GoogleMobileAds.VideoController) {
         // Implement this method to receive a notification when the video controller
         // pauses the ad.
     }
-    
-    public func videoControllerDidEndVideoPlayback(_ videoController: GoogleMobileAds.VideoController) {
+
+    nonisolated public func videoControllerDidEndVideoPlayback(_ videoController: GoogleMobileAds.VideoController) {
         // Implement this method to receive a notification when the video controller
         // stops playing the ad.
     }
-    
-    public func videoControllerDidMuteVideo(_ videoController: GoogleMobileAds.VideoController) {
+
+    nonisolated public func videoControllerDidMuteVideo(_ videoController: GoogleMobileAds.VideoController) {
         // Implement this method to receive a notification when the video controller
         // mutes the ad.
     }
-    
-    public func videoControllerDidUnmuteVideo(_ videoController: GoogleMobileAds.VideoController) {
+
+    nonisolated public func videoControllerDidUnmuteVideo(_ videoController: GoogleMobileAds.VideoController) {
         // Implement this method to receive a notification when the video controller
         // unmutes the ad.
     }
@@ -119,23 +163,23 @@ extension NativeAdViewModel: GoogleMobileAds.VideoControllerDelegate {
 
 // MARK: - GADNativeAdDelegate implementation
 extension NativeAdViewModel: GoogleMobileAds.NativeAdDelegate {
-    public func nativeAdDidRecordClick(_ nativeAd: GoogleMobileAds.NativeAd) {
+    nonisolated public func nativeAdDidRecordClick(_ nativeAd: GoogleMobileAds.NativeAd) {
         AdmobSwiftUI.log("\(#function) called", level: .debug)
     }
 
-    public func nativeAdDidRecordImpression(_ nativeAd: GoogleMobileAds.NativeAd) {
+    nonisolated public func nativeAdDidRecordImpression(_ nativeAd: GoogleMobileAds.NativeAd) {
         AdmobSwiftUI.log("\(#function) called", level: .debug)
     }
 
-    public func nativeAdWillPresentScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
+    nonisolated public func nativeAdWillPresentScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
         AdmobSwiftUI.log("\(#function) called", level: .debug)
     }
 
-    public func nativeAdWillDismissScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
+    nonisolated public func nativeAdWillDismissScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
         AdmobSwiftUI.log("\(#function) called", level: .debug)
     }
 
-    public func nativeAdDidDismissScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
+    nonisolated public func nativeAdDidDismissScreen(_ nativeAd: GoogleMobileAds.NativeAd) {
         AdmobSwiftUI.log("\(#function) called", level: .debug)
     }
 }

--- a/Sources/AdmobSwiftUI/Protocols/AdCoordinatorProtocol.swift
+++ b/Sources/AdmobSwiftUI/Protocols/AdCoordinatorProtocol.swift
@@ -8,13 +8,14 @@
 import UIKit
 
 /// Protocol that defines the common interface for all ad coordinators
+@available(*, deprecated, message: "Use FullScreenAdCoordinator instead. Will be removed in 4.0.")
 public protocol AdCoordinatorProtocol {
     /// Check if an ad is currently available to show
     var isAdAvailable: Bool { get }
-    
+
     /// Load an ad (fire-and-forget)
     func loadAd()
-    
+
     /// Show the loaded ad from the specified view controller
     /// - Parameter viewController: The view controller to present from
     /// - Throws: AdmobSwiftUIError if the ad cannot be shown
@@ -22,9 +23,10 @@ public protocol AdCoordinatorProtocol {
 }
 
 /// Protocol for coordinators that support async ad loading
+@available(*, deprecated, message: "Use FullScreenAdCoordinator instead. Will be removed in 4.0.")
 public protocol AsyncAdCoordinatorProtocol: AdCoordinatorProtocol {
     associatedtype AdType
-    
+
     /// Load an ad asynchronously and return it
     /// - Returns: The loaded ad instance
     /// - Throws: AdmobSwiftUIError if loading fails

--- a/Sources/AdmobSwiftUI/Protocols/FullScreenAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Protocols/FullScreenAdCoordinator.swift
@@ -1,0 +1,68 @@
+//
+//  FullScreenAdCoordinator.swift
+//  AdmobSwiftUI
+//
+//  Created by Claude on 2026/6/11.
+//
+
+import SwiftUI
+import UIKit
+
+/// Lifecycle state of a full-screen ad.
+public enum AdState: Sendable, Equatable {
+    /// No ad is loaded.
+    case idle
+    /// An ad request is in flight.
+    case loading
+    /// An ad is loaded and ready to present.
+    case ready
+    /// The ad is currently on screen.
+    case presenting
+}
+
+/// Reward earned from a rewarded ad.
+public struct AdReward: Sendable, Equatable {
+    public let amount: Int
+    public let type: String
+
+    public init(amount: Int, type: String) {
+        self.amount = amount
+        self.type = type
+    }
+}
+
+/// Unified async/await interface shared by full-screen ad coordinators.
+///
+/// `InterstitialAdCoordinator` and `AppOpenAdCoordinator` conform directly.
+/// `RewardedAdCoordinator` follows the same shape but its `present(from:)`
+/// suspends until the user earns the reward and returns an ``AdReward``.
+@MainActor
+public protocol FullScreenAdCoordinator: AnyObject, ObservableObject {
+    /// Current lifecycle state of the ad.
+    var adState: AdState { get }
+
+    /// Whether an ad is loaded and can be presented right now.
+    var isReady: Bool { get }
+
+    /// Load an ad, replacing any previously loaded one.
+    /// - Throws: ``AdmobSwiftUIError/adLoadFailed(_:)`` if the request fails.
+    func load() async throws
+
+    /// Present the loaded ad.
+    /// - Throws: ``AdmobSwiftUIError/adNotLoaded`` if no ad is ready.
+    func present(from viewController: UIViewController) throws
+
+    /// Load an ad if needed, then present it.
+    func loadAndPresent(from viewController: UIViewController) async throws
+}
+
+extension FullScreenAdCoordinator {
+    public var isReady: Bool { adState == .ready }
+
+    public func loadAndPresent(from viewController: UIViewController) async throws {
+        if !isReady {
+            try await load()
+        }
+        try present(from: viewController)
+    }
+}

--- a/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
+++ b/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
@@ -50,6 +50,14 @@ final class AdmobSwiftUITests: XCTestCase {
     func testConstants() throws {
         XCTAssertEqual(AdmobSwiftUI.Constants.appOpenAdExpirationInterval, 4 * 60 * 60)
         XCTAssertEqual(AdmobSwiftUI.Constants.nativeAdCacheMaxSize, 10)
+        XCTAssertEqual(AdmobSwiftUI.Constants.nativeAdDefaultRequestInterval, 60)
+    }
+
+    func testRewardNotEarnedErrorMessage() throws {
+        XCTAssertEqual(
+            AdmobSwiftUIError.rewardNotEarned.errorDescription,
+            "The rewarded ad was dismissed before the reward was earned"
+        )
     }
 }
 
@@ -101,7 +109,7 @@ final class CoordinatorInitializationTests: XCTestCase {
     func testRewardedAdCoordinatorWithCustomAdUnits() throws {
         let coordinator = RewardedAdCoordinator(
             adUnitID: "test-rewarded-id",
-            InterstitialID: "test-rewarded-interstitial-id"
+            interstitialAdUnitID: "test-rewarded-interstitial-id"
         )
         XCTAssertNotNil(coordinator)
     }
@@ -109,7 +117,80 @@ final class CoordinatorInitializationTests: XCTestCase {
     func testAppOpenAdCoordinatorDefaultInit() throws {
         let coordinator = AppOpenAdCoordinator()
         XCTAssertNotNil(coordinator)
-        XCTAssertFalse(coordinator.isAdAvailable)
+        XCTAssertFalse(coordinator.isReady)
+    }
+}
+
+@MainActor
+final class FullScreenAdCoordinatorStateTests: XCTestCase {
+
+    func testInterstitialInitialState() throws {
+        let coordinator = InterstitialAdCoordinator()
+        XCTAssertEqual(coordinator.adState, .idle)
+        XCTAssertFalse(coordinator.isReady)
+    }
+
+    func testInterstitialPresentWithoutLoadThrowsAdNotLoaded() throws {
+        let coordinator = InterstitialAdCoordinator()
+        XCTAssertThrowsError(try coordinator.present(from: UIViewController())) { error in
+            guard case AdmobSwiftUIError.adNotLoaded = error else {
+                return XCTFail("Expected adNotLoaded, got \(error)")
+            }
+        }
+        // A failed present must not leave the coordinator in a stuck state.
+        XCTAssertEqual(coordinator.adState, .idle)
+    }
+
+    func testAppOpenInitialState() throws {
+        let coordinator = AppOpenAdCoordinator()
+        XCTAssertEqual(coordinator.adState, .idle)
+        XCTAssertFalse(coordinator.isReady)
+    }
+
+    func testAppOpenPresentWithoutLoadThrowsAdNotLoaded() throws {
+        let coordinator = AppOpenAdCoordinator()
+        XCTAssertThrowsError(try coordinator.present(from: UIViewController())) { error in
+            guard case AdmobSwiftUIError.adNotLoaded = error else {
+                return XCTFail("Expected adNotLoaded, got \(error)")
+            }
+        }
+        XCTAssertEqual(coordinator.adState, .idle)
+    }
+
+    func testAppOpenAutoReloadsOnForegroundToggle() throws {
+        let coordinator = AppOpenAdCoordinator()
+        XCTAssertFalse(coordinator.autoReloadsOnForeground)
+        coordinator.autoReloadsOnForeground = true
+        XCTAssertTrue(coordinator.autoReloadsOnForeground)
+        coordinator.autoReloadsOnForeground = false
+        XCTAssertFalse(coordinator.autoReloadsOnForeground)
+    }
+
+    func testRewardedInitialState() throws {
+        let coordinator = RewardedAdCoordinator()
+        XCTAssertEqual(coordinator.adState, .idle)
+        XCTAssertFalse(coordinator.isReady)
+    }
+
+    func testRewardedPresentWithoutLoadThrowsAdNotLoaded() async throws {
+        let coordinator = RewardedAdCoordinator()
+        do {
+            _ = try await coordinator.present(from: UIViewController())
+            XCTFail("Expected present to throw")
+        } catch {
+            guard case AdmobSwiftUIError.adNotLoaded = error else {
+                return XCTFail("Expected adNotLoaded, got \(error)")
+            }
+        }
+        XCTAssertEqual(coordinator.adState, .idle)
+    }
+
+    func testAdRewardEquatable() throws {
+        let reward = AdReward(amount: 10, type: "coins")
+        XCTAssertEqual(reward, AdReward(amount: 10, type: "coins"))
+        XCTAssertNotEqual(reward, AdReward(amount: 5, type: "coins"))
+        XCTAssertEqual(reward.amount, 10)
+        XCTAssertEqual(reward.type, "coins")
     }
 }
 


### PR DESCRIPTION
Closes #12

## 變更內容

### 新 API
- **`FullScreenAdCoordinator` protocol**（`Protocols/FullScreenAdCoordinator.swift`）：`adState`（`idle/loading/ready/presenting`）、`isReady`、`load()`、`present(from:)`、`loadAndPresent(from:)`，全 `@MainActor` + `ObservableObject`
- **`AdState`**（Sendable enum）與 **`AdReward`**（Sendable struct，`amount` + `type`）
- **Interstitial / AppOpen** 直接 conform protocol；**Rewarded** 同形但 `present(from:)` suspend 到 earned、直接回傳 `AdReward`（dismiss 未領獎則丟出新錯誤 `rewardNotEarned`）
- **AppOpen 場景化 API**：`autoReloadsOnForeground`（dismiss 後與回前景自動補載）+ `presentIfAvailable(from:)`（容忍失敗、`vc` 可省略），取代手寫 scenePhase 樣板
- **NativeAdViewModel** 新增 `load() async throws`（continuation 橋接 AdLoader delegate）；`requestInterval` 預設值接上 `AdmobSwiftUI.Constants`（升為 public）

### Concurrency 修正
- `FullScreenContentDelegate` / `AdLoaderDelegate` conformance 改 `nonisolated` 方法 + `Task { @MainActor in }` 橋接 — 解決 callback 非主執行緒寫入 `@Published` 的 race condition
- Rewarded 的 continuation 由 `clean()` 統一保底 resume，不會洩漏 suspended caller

### v2 deprecated shims（3.x 保留、4.0 移除）
`loadAd()` / `loadInterstitialAd()` / `loadAppOpenAd()` / `loadAdAsync()` / `showAd(from:)` / `showAd(from:userDidEarnRewardHandler:)` / `refreshAd()` / `isAdAvailable` / `init(adUnitID:InterstitialID:)` / `AdCoordinatorProtocol` / `AsyncAdCoordinatorProtocol`

### Demo
- 主頁全面改用新 API（`loadAndPresent`、`AdReward` 顯示、`presentIfAvailable`）
- 新增 **Legacy v2 API** 頁：v2 寫法只產生 deprecation warning、不報 error，且實際可運作

## 驗收結果

- ✅ `xcodebuild build`（套件）零 error 零 warning
- ✅ `xcodebuild test` 31 tests 全綠（iPhone 17 模擬器）
- ✅ Demo 模擬器實測：
  - Interstitial：`loadAndPresent` 呈現成功
  - Rewarded：影片播畢「已發放獎勵」，UI 顯示 `Last reward: 10 coins`
  - App Open：`loadAndPresent` 呈現；dismiss 後自動補載 → `presentIfAvailable` 直接呈現；前後台切換（Safari 來回）後再次呈現成功
  - Legacy 頁：v2 `loadAd`+`showAd` shim 實測呈現 interstitial、`refreshAd` 載入 native（AdMob validator: no issues）
- ✅ Demo build 僅 7 個 deprecation warning（皆來自 Legacy 頁，符合預期）

🤖 Generated with [Claude Code](https://claude.com/claude-code)