### PR TITLE
Add collapsible banner style, ad events, and automatic height

### DIFF
--- a/Demo/AdmobSwitUIDemo.xcodeproj/project.pbxproj
+++ b/Demo/AdmobSwitUIDemo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1C415EEA2A37D10B00D03783 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C415EE92A37D10B00D03783 /* Assets.xcassets */; };
 		1C415EEE2A37D10B00D03783 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C415EED2A37D10B00D03783 /* Preview Assets.xcassets */; };
 		1CFF1F812BA5F29A00BD8164 /* AdmobSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 1CFF1F802BA5F29A00BD8164 /* AdmobSwiftUI */; };
+		7D9BB906D7A62A7AD41C2EF0 /* BannerStylesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245DBBAC71611D08BECFF1C4 /* BannerStylesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		1C415EEB2A37D10B00D03783 /* AdmobSwitUIDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AdmobSwitUIDemo.entitlements; sourceTree = "<group>"; };
 		1C415EED2A37D10B00D03783 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1C415EFC2A37D5EA00D03783 /* Info-demo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-demo.plist"; sourceTree = "<group>"; };
+		245DBBAC71611D08BECFF1C4 /* BannerStylesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BannerStylesView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				1C415EEB2A37D10B00D03783 /* AdmobSwitUIDemo.entitlements */,
 				1C415EEC2A37D10B00D03783 /* Preview Content */,
 				1C415EFC2A37D5EA00D03783 /* Info-demo.plist */,
+				245DBBAC71611D08BECFF1C4 /* BannerStylesView.swift */,
 			);
 			path = AdmobSwitUIDemo;
 			sourceTree = "<group>";
@@ -159,6 +162,7 @@
 			files = (
 				1C415EE82A37D10A00D03783 /* ContentView.swift in Sources */,
 				1C415EE62A37D10A00D03783 /* AdmobSwitUIDemoApp.swift in Sources */,
+				7D9BB906D7A62A7AD41C2EF0 /* BannerStylesView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/AdmobSwitUIDemo/BannerStylesView.swift
+++ b/Demo/AdmobSwitUIDemo/BannerStylesView.swift
@@ -1,0 +1,137 @@
+//
+//  BannerStylesView.swift
+//  AdmobSwitUIDemo
+//
+//  每種 banner style 一個分頁：anchored / inline / collapsible，
+//  並顯示 onAdEvent 事件與實際 ad size，驗證高度回報。
+//
+
+import SwiftUI
+import AdmobSwiftUI
+
+struct BannerStylesView: View {
+    enum StyleTab: String, CaseIterable, Identifiable {
+        case anchored = "Anchored"
+        case inline = "Inline"
+        case collapsible = "Collapsible"
+        var id: String { rawValue }
+    }
+
+    @State private var tab: StyleTab = .anchored
+    @State private var events: [String] = []
+    @State private var adSize: CGSize?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Style", selection: $tab) {
+                ForEach(StyleTab.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            switch tab {
+            case .anchored: anchoredDemo
+            case .inline: inlineDemo
+            case .collapsible: collapsibleDemo
+            }
+        }
+        .navigationTitle("Banner Styles")
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: tab) { _ in
+            events = []
+            adSize = nil
+        }
+    }
+
+    // MARK: - Tabs
+
+    /// Anchored：不加外部 frame，驗證 BannerView 會自己保留正確高度。
+    private var anchoredDemo: some View {
+        VStack {
+            eventLog
+            Spacer()
+            Text("⬇️ BannerView(style: .anchored)，無外部 frame")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            BannerView(style: .anchored, onAdEvent: handle)
+                .background(Color.red.opacity(0.15))
+                .id(StyleTab.anchored)
+        }
+    }
+
+    /// Inline：嵌在滾動列表中，高度在載入後由 didReceive 撐開。
+    private var inlineDemo: some View {
+        List {
+            Section { eventLog }
+            ForEach(1..<6) { i in
+                Text("List row \(i)")
+            }
+            BannerView(style: .inline, onAdEvent: handle)
+                .background(Color.blue.opacity(0.15))
+                .id(StyleTab.inline)
+                .listRowInsets(EdgeInsets())
+            ForEach(6..<20) { i in
+                Text("List row \(i)")
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    /// Collapsible：錨定在畫面底部，載入後先展開大版位、再收合成一般 anchored。
+    private var collapsibleDemo: some View {
+        VStack {
+            eventLog
+            Spacer()
+            Text("⬇️ BannerView(style: .collapsible(placement: .bottom))")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            BannerView(style: .collapsible(placement: .bottom), onAdEvent: handle)
+                .background(Color.green.opacity(0.15))
+                .id(StyleTab.collapsible)
+        }
+    }
+
+    // MARK: - Event log
+
+    private var eventLog: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Ad size: \(adSize.map { "\(Int($0.width)) x \(Int($0.height))" } ?? "—")")
+                .font(.footnote.bold())
+            ForEach(Array(events.suffix(8).enumerated()), id: \.offset) { _, event in
+                Text(event)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal)
+    }
+
+    private func handle(_ event: BannerAdEvent) {
+        switch event {
+        case .didReceive(let size):
+            adSize = size
+            events.append("didReceive \(Int(size.width)) x \(Int(size.height))")
+        case .didFailToReceive(let error):
+            events.append("didFail: \(error.localizedDescription)")
+        case .didRecordImpression:
+            events.append("didRecordImpression")
+        case .didRecordClick:
+            events.append("didRecordClick")
+        case .willPresentScreen:
+            events.append("willPresentScreen")
+        case .willDismissScreen:
+            events.append("willDismissScreen")
+        case .didDismissScreen:
+            events.append("didDismissScreen")
+        }
+    }
+}
+
+struct BannerStylesView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            BannerStylesView()
+        }
+    }
+}

--- a/Demo/AdmobSwitUIDemo/ContentView.swift
+++ b/Demo/AdmobSwitUIDemo/ContentView.swift
@@ -81,14 +81,16 @@ struct ContentView: View {
                         hiddenNative.toggle()
                     }
 
+                    NavigationLink("Banner Styles (anchored / inline / collapsible)") {
+                        BannerStylesView()
+                    }
+
                     NavigationLink("Legacy v2 API (deprecated)") {
                         LegacyAPIView()
                     }
 
-                    // SDK 13 large anchored adaptive banner is 50-150pt tall
-                    // (116pt at iPhone width); 50pt would clip it.
+                    // v3: BannerView 會依 ad size 自動保留高度，不再需要外部 frame
                     BannerView()
-                        .frame(height: 120)
                         .background(Color.red)
 
                     if !hiddenNative {

--- a/Sources/AdmobSwiftUI/Banner/BannerAdEvent.swift
+++ b/Sources/AdmobSwiftUI/Banner/BannerAdEvent.swift
@@ -1,0 +1,28 @@
+//
+//  BannerAdEvent.swift
+//  AdmobSwiftUI
+//
+
+import Foundation
+import CoreGraphics
+
+/// Lifecycle events emitted by ``BannerView`` via its `onAdEvent` closure.
+///
+/// All events are delivered on the main actor.
+public enum BannerAdEvent {
+    /// An ad was loaded. `adSize` is the actual rendered size — for inline
+    /// adaptive banners this is the only way to learn the final height.
+    case didReceive(adSize: CGSize)
+    /// The ad request failed.
+    case didFailToReceive(error: any Error)
+    /// An impression was recorded for the ad.
+    case didRecordImpression
+    /// A click was recorded for the ad.
+    case didRecordClick
+    /// The ad is about to present a full screen view (e.g. after a tap).
+    case willPresentScreen
+    /// The full screen view is about to be dismissed.
+    case willDismissScreen
+    /// The full screen view has been dismissed.
+    case didDismissScreen
+}

--- a/Sources/AdmobSwiftUI/Banner/BannerView.swift
+++ b/Sources/AdmobSwiftUI/Banner/BannerView.swift
@@ -1,6 +1,6 @@
 //
 //  BannerView.swift
-//  
+//
 //
 //  Created by minghui on 2023/6/13.
 //
@@ -8,18 +8,56 @@
 import SwiftUI
 import GoogleMobileAds
 
-public struct BannerView: UIViewControllerRepresentable {
-    @State private var viewWidth: CGFloat = .zero
-    @State private var currentAdSize: AdSize?
+/// A SwiftUI banner ad view that sizes itself to the ad it displays.
+///
+/// The view reserves the correct height automatically: anchored styles reserve
+/// the computed adaptive height as soon as the width is known (before the ad
+/// loads), and all styles update to the actual rendered height once the ad
+/// arrives. No external `.frame(height:)` is required.
+public struct BannerView: View {
     private let adUnitID: String
     private let style: BannerViewStyle
+    private let onAdEvent: (@MainActor (BannerAdEvent) -> Void)?
+    @State private var adHeight: CGFloat
 
-    public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.banner, style: BannerViewStyle = .anchored) {
+    /// - Parameters:
+    ///   - adUnitID: The banner ad unit ID. Defaults to the environment-aware ID.
+    ///   - style: Display style. See ``BannerViewStyle``.
+    ///   - onAdEvent: Optional closure receiving ``BannerAdEvent`` lifecycle
+    ///     events (load success/failure, impression, click, screen presentation).
+    public init(
+        adUnitID: String = AdmobSwiftUI.AdUnitIDs.banner,
+        style: BannerViewStyle = .anchored,
+        onAdEvent: (@MainActor (BannerAdEvent) -> Void)? = nil
+    ) {
         self.adUnitID = adUnitID
         self.style = style
+        self.onAdEvent = onAdEvent
+        // Placeholder until the real adaptive height is known (anchored: as
+        // soon as the width is measured; inline: when the ad loads).
+        _adHeight = State(initialValue: 50)
     }
 
-    public func makeUIViewController(context: Context) -> some UIViewController {
+    public var body: some View {
+        BannerViewRepresentable(
+            adUnitID: adUnitID,
+            style: style,
+            adHeight: $adHeight,
+            onAdEvent: onAdEvent
+        )
+        .frame(height: adHeight)
+    }
+}
+
+struct BannerViewRepresentable: UIViewControllerRepresentable {
+    let adUnitID: String
+    let style: BannerViewStyle
+    @Binding var adHeight: CGFloat
+    let onAdEvent: (@MainActor (BannerAdEvent) -> Void)?
+    @State private var viewWidth: CGFloat = .zero
+    @State private var currentAdSize: AdSize?
+
+    func makeUIViewController(context: Context) -> some UIViewController {
         let bannerViewController = BannerViewController()
         // The banner view lives on the coordinator: the representable struct is
         // recreated on every parent render, so an instance stored here would be
@@ -34,18 +72,18 @@ public struct BannerView: UIViewControllerRepresentable {
         return bannerViewController
     }
 
-    public func makeCoordinator() -> Coordinator {
+    func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
 
-    public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
         context.coordinator.parent = self
         AdmobSwiftUI.log("Banner view width updated: \(viewWidth)", level: .debug)
         guard viewWidth != .zero else { return }
 
         // Only reload if size actually changed
         let newAdSize: AdSize = switch style {
-        case .anchored:
+        case .anchored, .collapsible:
             // SDK 13: large anchored adaptive banner (50-150pt tall, supports video demand)
             largeAnchoredAdaptiveBanner(width: viewWidth)
         case .inline:
@@ -54,20 +92,32 @@ public struct BannerView: UIViewControllerRepresentable {
         if currentAdSize == nil || !isAdSizeEqualToSize(size1: currentAdSize!, size2: newAdSize) {
             DispatchQueue.main.async {
                 self.currentAdSize = newAdSize
+                // Anchored heights are exact once the width is known, so the
+                // layout can be reserved before the ad loads. The inline size's
+                // height is only an upper bound — wait for didReceive instead.
+                if case .inline = style {} else {
+                    self.adHeight = newAdSize.size.height
+                }
             }
             let bannerView = context.coordinator.bannerView
             bannerView.adSize = newAdSize
-            AdmobSwiftUI.log("Loading banner ad with size: \(newAdSize.size)", level: .debug)
-            bannerView.load(GoogleMobileAds.Request())
+            let request = GoogleMobileAds.Request()
+            if case .collapsible(let placement) = style {
+                let extras = Extras()
+                extras.additionalParameters = ["collapsible": placement.rawValue]
+                request.register(extras)
+            }
+            AdmobSwiftUI.log("Loading banner ad with size: \(newAdSize.size), style: \(style)", level: .debug)
+            bannerView.load(request)
         }
     }
 
     @MainActor
-    public class Coordinator: NSObject, BannerViewControllerWidthDelegate, GoogleMobileAds.BannerViewDelegate {
+    class Coordinator: NSObject, BannerViewControllerWidthDelegate, GoogleMobileAds.BannerViewDelegate {
         let bannerView = GoogleMobileAds.BannerView()
-        var parent: BannerView
+        var parent: BannerViewRepresentable
 
-        init(_ parent: BannerView) {
+        init(_ parent: BannerViewRepresentable) {
             self.parent = parent
         }
 
@@ -79,29 +129,58 @@ public struct BannerView: UIViewControllerRepresentable {
                 self.parent.viewWidth = width
             }
         }
-        
+
+        // MARK: - GoogleMobileAds.BannerViewDelegate methods
+
         public func bannerViewDidReceiveAd(_ bannerView: GoogleMobileAds.BannerView) {
-            AdmobSwiftUI.log("Banner ad received successfully", level: .debug)
+            let adSize = bannerView.adSize.size
+            AdmobSwiftUI.log("Banner ad received successfully, size: \(adSize)", level: .debug)
+            Task { @MainActor in
+                self.parent.adHeight = adSize.height
+                self.parent.onAdEvent?(.didReceive(adSize: adSize))
+            }
         }
-        
+
         public func bannerView(_ bannerView: GoogleMobileAds.BannerView, didFailToReceiveAdWithError error: Error) {
             AdmobSwiftUI.log("Banner ad failed to load: \(error.localizedDescription)", level: .error)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.didFailToReceive(error: error))
+            }
         }
-        
+
         public func bannerViewDidRecordImpression(_ bannerView: GoogleMobileAds.BannerView) {
             AdmobSwiftUI.log("Banner ad impression recorded", level: .debug)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.didRecordImpression)
+            }
         }
-        
+
+        public func bannerViewDidRecordClick(_ bannerView: GoogleMobileAds.BannerView) {
+            AdmobSwiftUI.log("Banner ad click recorded", level: .debug)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.didRecordClick)
+            }
+        }
+
         public func bannerViewWillPresentScreen(_ bannerView: GoogleMobileAds.BannerView) {
             AdmobSwiftUI.log("Banner ad will present screen", level: .debug)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.willPresentScreen)
+            }
         }
-        
+
         public func bannerViewWillDismissScreen(_ bannerView: GoogleMobileAds.BannerView) {
             AdmobSwiftUI.log("Banner ad will dismiss screen", level: .debug)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.willDismissScreen)
+            }
         }
-        
+
         public func bannerViewDidDismissScreen(_ bannerView: GoogleMobileAds.BannerView) {
             AdmobSwiftUI.log("Banner ad did dismiss screen", level: .debug)
+            Task { @MainActor in
+                self.parent.onAdEvent?(.didDismissScreen)
+            }
         }
     }
 }

--- a/Sources/AdmobSwiftUI/Banner/BannerViewStyle.swift
+++ b/Sources/AdmobSwiftUI/Banner/BannerViewStyle.swift
@@ -8,9 +8,32 @@
 import Foundation
 
 /// Banner ad display style
-public enum BannerViewStyle {
-    /// Anchored adaptive banner - fixed at top or bottom of screen
+public enum BannerViewStyle: Equatable, Sendable {
+    /// Anchored adaptive banner - fixed at top or bottom of screen.
+    /// Uses the large anchored adaptive size (50-150pt tall, supports video demand).
     case anchored
-    /// Inline adaptive banner - embedded within scrollable content
+    /// Inline adaptive banner - embedded within scrollable content.
+    /// Height is unknown until the ad loads; observe ``BannerAdEvent/didReceive(adSize:)``.
     case inline
+    /// Collapsible banner - an anchored adaptive banner that initially shows a
+    /// larger overlay and collapses to the regular anchored size.
+    ///
+    /// Collapsible banners are only supported for anchored adaptive banners,
+    /// which is why this is a separate style rather than an option on `.inline`.
+    ///
+    /// - Important: Google has strict policies on collapsible banners (display
+    ///   frequency, accidental-click prevention, close button behavior, etc.).
+    ///   This package only provides the capability; policy compliance is the
+    ///   responsibility of the integrating app. See:
+    ///   https://support.google.com/admob/answer/14076373
+    case collapsible(placement: CollapsiblePlacement)
+
+    /// Where the collapsible banner is anchored on screen. The expanded overlay
+    /// grows from this edge, so it must match the banner's actual position.
+    public enum CollapsiblePlacement: String, Equatable, Sendable {
+        /// Banner anchored at the top of the screen; overlay expands downward.
+        case top
+        /// Banner anchored at the bottom of the screen; overlay expands upward.
+        case bottom
+    }
 }

--- a/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
+++ b/Tests/AdmobSwiftUITests/AdmobSwiftUITests.swift
@@ -260,6 +260,45 @@ final class UIViewExtensionsTests: XCTestCase {
     }
 }
 
+final class BannerViewStyleTests: XCTestCase {
+
+    func testCollapsiblePlacementRawValuesMatchAdMobParameters() throws {
+        // Extras additionalParameters 的值必須是 "top" / "bottom"（Google 規格）
+        XCTAssertEqual(BannerViewStyle.CollapsiblePlacement.top.rawValue, "top")
+        XCTAssertEqual(BannerViewStyle.CollapsiblePlacement.bottom.rawValue, "bottom")
+    }
+
+    func testStyleEquatable() throws {
+        XCTAssertEqual(BannerViewStyle.anchored, .anchored)
+        XCTAssertEqual(BannerViewStyle.inline, .inline)
+        XCTAssertEqual(
+            BannerViewStyle.collapsible(placement: .bottom),
+            .collapsible(placement: .bottom)
+        )
+        XCTAssertNotEqual(
+            BannerViewStyle.collapsible(placement: .top),
+            .collapsible(placement: .bottom)
+        )
+        XCTAssertNotEqual(BannerViewStyle.anchored, .inline)
+    }
+}
+
+@MainActor
+final class BannerViewTests: XCTestCase {
+
+    func testBannerViewInitWithAllStyles() throws {
+        XCTAssertNotNil(BannerView(style: .anchored))
+        XCTAssertNotNil(BannerView(style: .inline))
+        XCTAssertNotNil(BannerView(style: .collapsible(placement: .top)))
+        XCTAssertNotNil(BannerView(style: .collapsible(placement: .bottom)))
+    }
+
+    func testBannerViewInitWithAdEventClosure() throws {
+        let view = BannerView(adUnitID: "custom-banner-id", style: .anchored) { _ in }
+        XCTAssertNotNil(view)
+    }
+}
+
 @MainActor
 final class NativeAdViewStyleTests: XCTestCase {
 


### PR DESCRIPTION
Closes #13. Also fixes #9 (BannerView default frame height).

## 內容

### `.collapsible` banner style（#13）
- `BannerViewStyle` 新增 `.collapsible(placement: .top / .bottom)`，內部沿用 large anchored adaptive size
- Collapsible 僅支援 anchored adaptive — 以獨立 enum case 在型別層防呆（無法配 inline）
- 請求時註冊 `Extras().additionalParameters = ["collapsible": placement]`
- Google 政策限制（展示頻率／誤觸）寫入 doc comment，政策責任由接入 App 承擔

### 高度回報 + `onAdEvent`（修 #9）
- `BannerView` 重構為 SwiftUI `View` 包內部 representable，**自動保留正確高度**：
  - anchored / collapsible：寬度量到後立即以 adaptive 計算高度保留版面（載入前）
  - 所有 style：`didReceive` 後更新為實際渲染高度（inline 唯一可靠來源）
  - 不再需要外部 `.frame(height:)`，List row 不會再裁切 banner
- 新增 `BannerAdEvent`：`didReceive(adSize:)` / `didFailToReceive` / `didRecordImpression` / `didRecordClick` / `willPresentScreen` / `willDismissScreen` / `didDismissScreen`，全部 main actor 派送

### Demo
- 新增 Banner Styles 頁：anchored / inline / collapsible 三分頁，含事件 log 與 ad size 顯示

## 驗證

- `xcodebuild build`（generic iOS Simulator）✅
- `xcodebuild test`（iPhone 17）：35 tests 全綠 ✅
- Demo build ✅（僅 Legacy 頁預期 deprecation warnings）
- 模擬器實測（iPhone 17, iOS 26.2）：
  - anchored：無外部 frame 完整顯示，回報 402x126 ✅
  - inline：List 內載入後撐開 row（402x335），滾動正常 ✅
  - collapsible：載入即展開大版位 → 點 chevron 收合回 126pt anchored；事件序 didReceive → impression → willPresentScreen →（收合）willDismissScreen → didDismissScreen ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)