### PR TITLE
[v3] UMP 同意管理（GDPR）+ ATT 整合

### DIFF
--- a/Demo/AdmobSwitUIDemo.xcodeproj/project.pbxproj
+++ b/Demo/AdmobSwitUIDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		057E5BF1ACD300FF3933170C /* ConsentDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8710092188B485C0DAA46F5C /* ConsentDemoView.swift */; };
 		1C415EE62A37D10A00D03783 /* AdmobSwitUIDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C415EE52A37D10A00D03783 /* AdmobSwitUIDemoApp.swift */; };
 		1C415EE82A37D10A00D03783 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C415EE72A37D10A00D03783 /* ContentView.swift */; };
 		1C415EEA2A37D10B00D03783 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C415EE92A37D10B00D03783 /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 		1C415EED2A37D10B00D03783 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1C415EFC2A37D5EA00D03783 /* Info-demo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-demo.plist"; sourceTree = "<group>"; };
 		245DBBAC71611D08BECFF1C4 /* BannerStylesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BannerStylesView.swift; sourceTree = "<group>"; };
+		8710092188B485C0DAA46F5C /* ConsentDemoView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentDemoView.swift; sourceTree = "<group>"; };
 		FBAFD8D16DBDEF6AFBD21821 /* NativeAdStylesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeAdStylesView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -68,6 +70,7 @@
 				1C415EFC2A37D5EA00D03783 /* Info-demo.plist */,
 				245DBBAC71611D08BECFF1C4 /* BannerStylesView.swift */,
 				FBAFD8D16DBDEF6AFBD21821 /* NativeAdStylesView.swift */,
+				8710092188B485C0DAA46F5C /* ConsentDemoView.swift */,
 			);
 			path = AdmobSwitUIDemo;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 				1C415EE62A37D10A00D03783 /* AdmobSwitUIDemoApp.swift in Sources */,
 				7D9BB906D7A62A7AD41C2EF0 /* BannerStylesView.swift in Sources */,
 				7C5249A9F34D5E8BE8520C31 /* NativeAdStylesView.swift in Sources */,
+				057E5BF1ACD300FF3933170C /* ConsentDemoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/AdmobSwitUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/AdmobSwitUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
       "state" : {
-        "revision" : "cfe8b2ae16b9bc81f4cdf1d1a12a01a452489c32",
-        "version" : "2.3.0"
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
       }
     }
   ],

--- a/Demo/AdmobSwitUIDemo/AdmobSwitUIDemoApp.swift
+++ b/Demo/AdmobSwitUIDemo/AdmobSwitUIDemoApp.swift
@@ -10,18 +10,20 @@ import AdmobSwiftUI
 
 @main
 struct AdmobSwitUIDemoApp: App {
-    
-    init() {
-        // 使用新的初始化方法，啟用調試模式
-        let config = AdmobSwiftUI.Configuration(
-            enableDebugMode: true  // 啟用測試廣告
-        )
-        AdmobSwiftUI.initialize(with: config)
-    }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .task {
+                    // v3 async 初始化：先跑 UMP 同意流程，canRequestAds 後才啟動 SDK。
+                    // 想完整體驗 EEA 同意表單流程，請進「Consent (UMP + ATT)」頁面。
+                    let config = AdmobSwiftUI.Configuration(
+                        enableDebugMode: true  // 啟用測試廣告
+                    )
+                    await AdmobSwiftUI.initialize(with: config, consentMode: .gatherFirst)
+                    // Google 建議：UMP 流程完成後再請求 ATT
+                    await ConsentManager.shared.requestTrackingAuthorization()
+                }
         }
     }
 }

--- a/Demo/AdmobSwitUIDemo/ConsentDemoView.swift
+++ b/Demo/AdmobSwitUIDemo/ConsentDemoView.swift
@@ -1,0 +1,121 @@
+//
+//  ConsentDemoView.swift
+//  AdmobSwitUIDemo
+//
+//  UMP 同意流程（GDPR）+ ATT 完整展示頁。
+//  用 debug geography 強制 EEA，可重複走「reset → gather → 同意表單 → privacy options」流程。
+//
+
+import AdmobSwiftUI
+import AppTrackingTransparency
+import SwiftUI
+
+struct ConsentDemoView: View {
+    @ObservedObject private var consentManager = ConsentManager.shared
+
+    @State private var attStatus: ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
+    @State private var lastMessage = ""
+    @State private var isWorking = false
+
+    var body: some View {
+        List {
+            Section("目前狀態") {
+                LabeledContent("consentStatus", value: String(describing: consentManager.consentStatus))
+                LabeledContent("canRequestAds", value: consentManager.canRequestAds ? "true" : "false")
+                LabeledContent("isPrivacyOptionsRequired", value: consentManager.isPrivacyOptionsRequired ? "true" : "false")
+                LabeledContent("ATT status", value: attStatusDescription)
+            }
+
+            Section("同意流程") {
+                Button("Gather Consent（模擬 EEA，必出表單）") {
+                    run {
+                        try await consentManager.gatherConsent(
+                            debugSettings: ConsentDebugSettings(geography: .eea)
+                        )
+                        lastMessage = "EEA 流程完成，canRequestAds = \(consentManager.canRequestAds)"
+                    }
+                }
+
+                Button("Gather Consent（真實地理位置）") {
+                    run {
+                        try await consentManager.gatherConsent()
+                        lastMessage = "真實流程完成，canRequestAds = \(consentManager.canRequestAds)"
+                    }
+                }
+
+                Button("Privacy Options（設定頁入口）") {
+                    run {
+                        try await consentManager.presentPrivacyOptionsForm()
+                        lastMessage = "Privacy options 表單已關閉"
+                    }
+                }
+                .disabled(!consentManager.isPrivacyOptionsRequired)
+            }
+
+            Section("ATT") {
+                Button("Request Tracking Authorization") {
+                    run {
+                        attStatus = await consentManager.requestTrackingAuthorization()
+                        lastMessage = "ATT status = \(attStatusDescription)"
+                    }
+                }
+            }
+
+            Section("Debug") {
+                Button("Reset（清除同意狀態，重走流程）", role: .destructive) {
+                    consentManager.reset()
+                    lastMessage = "已 reset，可重新 gather"
+                }
+
+                Button("重新啟動 SDK（initialize gatherFirst）") {
+                    run {
+                        await AdmobSwiftUI.initialize(
+                            with: AdmobSwiftUI.Configuration(enableDebugMode: true),
+                            consentMode: .gatherFirst
+                        )
+                        lastMessage = "initialize 完成，isInitialized = \(AdmobSwiftUI.isInitialized)"
+                    }
+                }
+            }
+
+            if !lastMessage.isEmpty {
+                Section("結果") {
+                    Text(lastMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Consent (UMP + ATT)")
+        .navigationBarTitleDisplayMode(.inline)
+        .disabled(isWorking)
+    }
+
+    private var attStatusDescription: String {
+        switch attStatus {
+        case .notDetermined: return "notDetermined"
+        case .restricted: return "restricted"
+        case .denied: return "denied"
+        case .authorized: return "authorized"
+        @unknown default: return "unknown(\(attStatus.rawValue))"
+        }
+    }
+
+    private func run(_ work: @escaping () async throws -> Void) {
+        Task {
+            isWorking = true
+            defer { isWorking = false }
+            do {
+                try await work()
+            } catch {
+                lastMessage = "錯誤：\(error.localizedDescription)"
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ConsentDemoView()
+    }
+}

--- a/Demo/AdmobSwitUIDemo/ContentView.swift
+++ b/Demo/AdmobSwitUIDemo/ContentView.swift
@@ -81,6 +81,10 @@ struct ContentView: View {
                         hiddenNative.toggle()
                     }
 
+                    NavigationLink("Consent (UMP + ATT)") {
+                        ConsentDemoView()
+                    }
+
                     NavigationLink("Banner Styles (anchored / inline / collapsible)") {
                         BannerStylesView()
                     }

--- a/Demo/AdmobSwitUIDemo/Info-demo.plist
+++ b/Demo/AdmobSwitUIDemo/Info-demo.plist
@@ -6,6 +6,8 @@
 	<string>Your data will be used to deliver personalized ads to you.</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<key>GADDelayAppMeasurementInit</key>
+	<true/>
     <key>SKAdNetworkItems</key>
     <array>
       <dict>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "75452e0977cb3c2f11e964e01cd639dac42202bc251ed4dee5233e4fcac4eb9d",
+  "originHash" : "28eb30a74fa75ad9f453093ffb9139570b37f0148ed852fc999db4aba4aea473",
   "pins" : [
     {
       "identity" : "swift-package-manager-google-mobile-ads",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
       "state" : {
-        "revision" : "668673ea23b3e71b9f2540d8fb9464c4dc32ecc0",
-        "version" : "2.2.0"
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,17 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "13.0.0"),
+        // GoogleMobileAds already depends on UMP ("1.1.0"..<"4.0.0"), but the Swift API
+        // surface changed in UMP 3.0 (UMPConsentInformation -> ConsentInformation, etc.).
+        // Pin >= 3.0.0 explicitly so ConsentManager always compiles against the new names.
+        .package(url: "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git", from: "3.0.0"),
     ],
     targets: [
         .target(
             name: "AdmobSwiftUI",
             dependencies: [
-                .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads")
+                .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads"),
+                .product(name: "GoogleUserMessagingPlatform", package: "swift-package-manager-google-user-messaging-platform"),
             ],
             resources: [
                 .process("Resources")

--- a/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
+++ b/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
@@ -35,25 +35,64 @@ public struct AdmobSwiftUI {
         }
     }
     
-    /// Initialize AdmobSwiftUI with configuration
+    /// Initialize AdmobSwiftUI with configuration, integrating the UMP consent flow.
+    ///
+    /// With `.gatherFirst` (default), the full UMP consent flow runs first and the
+    /// Google Mobile Ads SDK only starts once `ConsentManager.shared.canRequestAds`
+    /// is `true`. A consent flow failure (e.g. network error) does not block startup
+    /// as long as a previous session already established that ads can be requested.
+    ///
+    /// If consent could not be established, the SDK is not started — calling this
+    /// method again later (e.g. on next foreground) retries the whole flow.
+    ///
+    /// - Parameters:
+    ///   - configuration: AdMob configuration settings
+    ///   - consentMode: How to handle user consent before starting the SDK
+    public static func initialize(
+        with configuration: Configuration = Configuration(),
+        consentMode: ConsentMode = .gatherFirst
+    ) async {
+        applyRequestConfiguration(configuration)
+
+        if consentMode == .gatherFirst {
+            do {
+                try await ConsentManager.shared.gatherConsent()
+            } catch {
+                log("Continuing initialization despite consent failure: \(error.localizedDescription)", level: .warning)
+            }
+            guard await ConsentManager.shared.canRequestAds else {
+                log("Cannot request ads without consent; SDK start deferred. Call initialize again to retry.", level: .warning)
+                return
+            }
+        }
+
+        let status = await MobileAds.shared.start()
+        log("Google Mobile Ads SDK initialized with status: \(status.adapterStatusesByClassName)", level: .info)
+    }
+
+    /// Initialize AdmobSwiftUI with configuration (no consent handling)
     /// - Parameter configuration: AdMob configuration settings
+    @available(*, deprecated, message: "Use the async initialize(with:consentMode:) instead, which integrates the UMP consent flow required for GDPR compliance.")
     public static func initialize(with configuration: Configuration = Configuration()) {
+        applyRequestConfiguration(configuration)
+        MobileAds.shared.start { status in
+            log("Google Mobile Ads SDK initialized with status: \(status.adapterStatusesByClassName)", level: .info)
+        }
+    }
+
+    private static func applyRequestConfiguration(_ configuration: Configuration) {
         let requestConfiguration = MobileAds.shared.requestConfiguration
-        
+
         // Configure test devices
         if configuration.enableDebugMode {
             requestConfiguration.testDeviceIdentifiers = ["ca-app-pub-3940256099942544~1458002511"]
         } else if let testDevices = configuration.testDeviceIdentifiers {
             requestConfiguration.testDeviceIdentifiers = testDevices
         }
-        
+
         // Configure max ad content rating
         if let maxRating = configuration.maxAdContentRating {
             requestConfiguration.maxAdContentRating = maxRating
-        }
-        
-        MobileAds.shared.start { status in
-            log("Google Mobile Ads SDK initialized with status: \(status.adapterStatusesByClassName)", level: .info)
         }
     }
     
@@ -213,7 +252,8 @@ public enum AdmobSwiftUIError: Error, LocalizedError {
     case adExpired
     case invalidConfiguration(String)
     case rewardNotEarned
-    
+    case consentGatheringFailed(Error)
+
     public var errorDescription: String? {
         switch self {
         case .adNotLoaded:
@@ -230,6 +270,8 @@ public enum AdmobSwiftUIError: Error, LocalizedError {
             return "Invalid configuration: \(message)"
         case .rewardNotEarned:
             return "The rewarded ad was dismissed before the reward was earned"
+        case .consentGatheringFailed(let error):
+            return "Failed to gather user consent: \(error.localizedDescription)"
         }
     }
 }

--- a/Sources/AdmobSwiftUI/Consent/ConsentManager.swift
+++ b/Sources/AdmobSwiftUI/Consent/ConsentManager.swift
@@ -1,0 +1,193 @@
+import AppTrackingTransparency
+import Foundation
+import UIKit
+import UserMessagingPlatform
+
+// MARK: - Public Types
+
+/// The user's consent status, mirroring UMP's `ConsentInformation.consentStatus`.
+public enum ConsentStatus: Sendable, Equatable {
+    /// Consent status is unknown; `gatherConsent` has not completed yet.
+    case unknown
+    /// Consent is required but has not been obtained.
+    case required
+    /// Consent is not required (e.g. user outside a regulated region).
+    case notRequired
+    /// Consent has been obtained from the user.
+    case obtained
+
+    init(_ status: UserMessagingPlatform.ConsentStatus) {
+        switch status {
+        case .required: self = .required
+        case .notRequired: self = .notRequired
+        case .obtained: self = .obtained
+        case .unknown: self = .unknown
+        @unknown default: self = .unknown
+        }
+    }
+}
+
+/// How `AdmobSwiftUI.initialize(with:consentMode:)` handles consent before starting the SDK.
+public enum ConsentMode: Sendable, Equatable {
+    /// Run the full UMP consent flow first; the Mobile Ads SDK starts only once
+    /// `ConsentManager.shared.canRequestAds` is `true`.
+    case gatherFirst
+    /// Skip consent handling and start the SDK immediately.
+    /// The app is responsible for driving `ConsentManager` itself.
+    case manual
+}
+
+/// Debug overrides for testing consent flows (e.g. simulating an EEA user).
+///
+/// Debug features are always enabled for simulators; physical devices must be
+/// listed in `testDeviceIdentifiers` (the device's UMP hashed ID is printed to
+/// the console on the first consent request).
+public struct ConsentDebugSettings: Sendable, Equatable {
+    /// Simulated geography for consent testing.
+    public enum Geography: Sendable, Equatable {
+        /// No geography override.
+        case disabled
+        /// Device appears as if located in the EEA (GDPR applies).
+        case eea
+        /// Device appears as if located in a regulated US state.
+        case regulatedUSState
+        /// Device appears as if located in a region with no regulation in force.
+        case other
+    }
+
+    public var geography: Geography
+    public var testDeviceIdentifiers: [String]
+
+    public init(geography: Geography = .disabled, testDeviceIdentifiers: [String] = []) {
+        self.geography = geography
+        self.testDeviceIdentifiers = testDeviceIdentifiers
+    }
+
+    var umpDebugSettings: DebugSettings {
+        let settings = DebugSettings()
+        settings.testDeviceIdentifiers = testDeviceIdentifiers
+        switch geography {
+        case .disabled: settings.geography = .disabled
+        case .eea: settings.geography = .EEA
+        case .regulatedUSState: settings.geography = .regulatedUSState
+        case .other: settings.geography = .other
+        }
+        return settings
+    }
+}
+
+// MARK: - ConsentManager
+
+/// Manages the UMP (User Messaging Platform) consent flow for GDPR and other
+/// privacy regulations, plus the App Tracking Transparency prompt.
+///
+/// Typical usage:
+/// ```swift
+/// // At app startup (handled automatically by `AdmobSwiftUI.initialize(consentMode: .gatherFirst)`):
+/// try await ConsentManager.shared.gatherConsent()
+/// await ConsentManager.shared.requestTrackingAuthorization()
+///
+/// // In Settings, when `isPrivacyOptionsRequired` is true:
+/// try await ConsentManager.shared.presentPrivacyOptionsForm()
+/// ```
+@MainActor
+public final class ConsentManager: ObservableObject {
+
+    public static let shared = ConsentManager()
+
+    /// The user's current consent status. Updated after every consent operation.
+    @Published public private(set) var consentStatus: ConsentStatus = .unknown
+
+    /// Whether ads can be requested. `true` once consent has been gathered
+    /// (or determined unnecessary), including values persisted from a previous session.
+    public var canRequestAds: Bool {
+        ConsentInformation.shared.canRequestAds
+    }
+
+    /// Whether the app must offer the user an entry point (e.g. in Settings)
+    /// to modify their privacy options.
+    public var isPrivacyOptionsRequired: Bool {
+        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+    }
+
+    private init() {
+        consentStatus = ConsentStatus(ConsentInformation.shared.consentStatus)
+    }
+
+    /// Runs the full UMP consent flow: requests a consent info update, then
+    /// automatically presents the consent form if one is required.
+    ///
+    /// Call this once per app session before loading ads. If the user already
+    /// made a choice in a previous session, no form is shown.
+    ///
+    /// - Parameters:
+    ///   - viewController: The view controller to present the consent form from.
+    ///     Pass `nil` (default) to let UMP find the top view controller.
+    ///   - debugSettings: Optional debug overrides, e.g. to simulate an EEA user.
+    ///   - tagForUnderAgeOfConsent: Whether the user is tagged as under the age of consent.
+    /// - Throws: `AdmobSwiftUIError.consentGatheringFailed` if the consent info
+    ///   update or form presentation fails (e.g. network error).
+    public func gatherConsent(
+        from viewController: UIViewController? = nil,
+        debugSettings: ConsentDebugSettings? = nil,
+        tagForUnderAgeOfConsent: Bool = false
+    ) async throws {
+        let parameters = RequestParameters()
+        parameters.isTaggedForUnderAgeOfConsent = tagForUnderAgeOfConsent
+        if let debugSettings {
+            parameters.debugSettings = debugSettings.umpDebugSettings
+        }
+
+        defer { syncStatus() }
+        do {
+            try await ConsentInformation.shared.requestConsentInfoUpdate(with: parameters)
+            syncStatus()
+            try await ConsentForm.loadAndPresentIfRequired(from: viewController)
+            AdmobSwiftUI.log("Consent gathered. status=\(consentStatus), canRequestAds=\(canRequestAds)", level: .info)
+        } catch {
+            AdmobSwiftUI.log("Consent gathering failed: \(error.localizedDescription)", level: .error)
+            throw AdmobSwiftUIError.consentGatheringFailed(error)
+        }
+    }
+
+    /// Presents the privacy options form, letting the user revisit their consent
+    /// choices. Call this from a UI entry point (e.g. a "Privacy Options" button
+    /// in Settings) when `isPrivacyOptionsRequired` is `true`.
+    ///
+    /// - Parameter viewController: The view controller to present from.
+    ///   Pass `nil` (default) to let UMP find the top view controller.
+    /// - Throws: `AdmobSwiftUIError.consentGatheringFailed` if no form could be presented.
+    public func presentPrivacyOptionsForm(from viewController: UIViewController? = nil) async throws {
+        defer { syncStatus() }
+        do {
+            try await ConsentForm.presentPrivacyOptionsForm(from: viewController)
+        } catch {
+            AdmobSwiftUI.log("Privacy options form failed: \(error.localizedDescription)", level: .error)
+            throw AdmobSwiftUIError.consentGatheringFailed(error)
+        }
+    }
+
+    /// Requests App Tracking Transparency authorization.
+    ///
+    /// Google recommends requesting ATT *after* the UMP consent flow completes.
+    /// Requires `NSUserTrackingUsageDescription` in the app's Info.plist.
+    ///
+    /// - Returns: The resulting authorization status.
+    @discardableResult
+    public func requestTrackingAuthorization() async -> ATTrackingManager.AuthorizationStatus {
+        let status = await ATTrackingManager.requestTrackingAuthorization()
+        AdmobSwiftUI.log("ATT authorization status: \(status.rawValue)", level: .info)
+        return status
+    }
+
+    /// Clears all consent state from persistent storage. Intended for debugging
+    /// and testing only — never call this in production flows.
+    public func reset() {
+        ConsentInformation.shared.reset()
+        syncStatus()
+    }
+
+    private func syncStatus() {
+        consentStatus = ConsentStatus(ConsentInformation.shared.consentStatus)
+    }
+}


### PR DESCRIPTION
Closes #15

## 變更內容

### ConsentManager（新增 `Sources/AdmobSwiftUI/Consent/`）
- `@MainActor public final class ConsentManager: ObservableObject`，依 issue API 草案實作：
  - `gatherConsent(from:debugSettings:tagForUnderAgeOfConsent:)` — 完整 UMP 流程（requestConsentInfoUpdate → 需要時自動呈現同意表單）
  - `presentPrivacyOptionsForm(from:)` — 設定頁「隱私選項」入口
  - `requestTrackingAuthorization()` — ATT，建議在 UMP 之後呼叫
  - `reset()` — debug/測試用
  - `@Published consentStatus`、`canRequestAds`、`isPrivacyOptionsRequired`
- 公開型別：`ConsentStatus`、`ConsentMode`（`.gatherFirst` / `.manual`）、`ConsentDebugSettings`（geography 含 `.eea`、`.regulatedUSState`、`.other`）
- `AdmobSwiftUIError` 新增 `consentGatheringFailed(Error)`

### async initialize 整合
- 新增 `initialize(with:consentMode:) async`：`.gatherFirst` 模式下 `canRequestAds == true` 才 `MobileAds.shared.start()`；失敗時不啟動，重呼叫即重試
- 舊同步 `initialize(with:)` 標 deprecated

### UMP 依賴驗證結果（issue 工作項 1）
GoogleMobileAds 確實傳遞依賴 UMP，可直接 `import UserMessagingPlatform`；**但** GMA 13.5 允許 UMP `1.1.0..<4.0.0`，而 UMP 3.0 重新命名了整個 Swift API surface（`UMPConsentInformation` → `ConsentInformation` 等），僅靠傳遞依賴會讓編譯結果隨解析版本而定。因此 `Package.swift` 顯式 pin UMP `from: "3.0.0"`。

### Demo
- 新增「Consent (UMP + ATT)」展示頁：狀態顯示、EEA debug gather、真實地理 gather、privacy options、ATT、reset、重新 initialize
- App 入口改用 async `initialize(consentMode: .gatherFirst)` + ATT
- `Info-demo.plist` 補 `GADDelayAppMeasurementInit`（`NSUserTrackingUsageDescription` 原本就有）

## 驗收條件驗證（iPhone 17 模擬器實測）

- ✅ 首啟 `gatherFirst`：UMP 表單 → ATT 提示（順序正確、status `authorized`），廣告正常載入
- ✅ Demo 強制 EEA：reset 後 gather 必出 GDPR 表單，同意後 `consentStatus=obtained`、`canRequestAds=true`、`isPrivacyOptionsRequired=true`
- ✅ Privacy options 表單可呈現；reset 後流程可重走
- ✅ 非 EEA 路徑不阻塞廣告載入
- ✅ `xcodebuild build`（package + Demo）零 error；`xcodebuild test` 36/36 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)