### PR TITLE
Rebuild tests, add CI, switch to Swift 6 language mode (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Package tests (iOS Simulator)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      # GoogleMobileAds is an iOS-only binary target, so `swift test` on macOS
+      # cannot work — tests must run through xcodebuild with a simulator destination.
+      - name: Run package tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme AdmobSwiftUI \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            CODE_SIGNING_ALLOWED=NO
+
+  build-demo:
+    name: Build demo app
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build demo
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Demo/AdmobSwitUIDemo.xcodeproj \
+            -scheme AdmobSwitUIDemo \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO

--- a/Package.swift
+++ b/Package.swift
@@ -30,17 +30,13 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
-                // Stay on Swift 5 mode for now: surface strict-concurrency issues as
-                // warnings first; the switch to Swift 6 mode lands with the test rebuild.
-                .swiftLanguageMode(.v5),
-                .enableUpcomingFeature("StrictConcurrency"),
+                .swiftLanguageMode(.v6),
             ]),
         .testTarget(
             name: "AdmobSwiftUITests",
             dependencies: ["AdmobSwiftUI"],
             swiftSettings: [
-                .swiftLanguageMode(.v5),
-                .enableUpcomingFeature("StrictConcurrency"),
+                .swiftLanguageMode(.v6),
             ]),
     ]
 )

--- a/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
+++ b/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
@@ -20,10 +20,18 @@ public struct AdmobSwiftUI {
     
     /// Configuration for AdMob initialization
     public struct Configuration {
+        /// Device identifiers that should always receive test ads.
         public let testDeviceIdentifiers: [String]?
+        /// Maximum content rating of the ads served to this app.
         public let maxAdContentRating: GADMaxAdContentRating?
+        /// When `true`, registers a simulator test-device identifier automatically.
         public let enableDebugMode: Bool
-        
+
+        /// Creates a configuration.
+        /// - Parameters:
+        ///   - testDeviceIdentifiers: Device identifiers that should always receive test ads.
+        ///   - maxAdContentRating: Maximum content rating of served ads.
+        ///   - enableDebugMode: Registers a simulator test-device identifier when `true`.
         public init(
             testDeviceIdentifiers: [String]? = nil,
             maxAdContentRating: GADMaxAdContentRating? = nil,
@@ -245,15 +253,24 @@ public struct AdmobSwiftUI {
 
 /// Unified error types for AdmobSwiftUI
 public enum AdmobSwiftUIError: Error, LocalizedError {
+    /// `present` was called before an ad finished loading.
     case adNotLoaded
+    /// The ad request failed; the underlying SDK error is attached.
     case adLoadFailed(Error)
+    /// The SDK failed to present the ad; the reason is attached.
     case presentationFailed(String)
+    /// The Google Mobile Ads SDK has not been started yet.
     case sdkNotInitialized
+    /// The loaded ad has expired (e.g. an App Open ad older than 4 hours).
     case adExpired
+    /// A configuration value is invalid; details are attached.
     case invalidConfiguration(String)
+    /// The rewarded ad was dismissed before the user earned the reward.
     case rewardNotEarned
+    /// The UMP consent info update or form presentation failed.
     case consentGatheringFailed(Error)
 
+    /// A human-readable description of the error.
     public var errorDescription: String? {
         switch self {
         case .adNotLoaded:
@@ -278,10 +295,15 @@ public enum AdmobSwiftUIError: Error, LocalizedError {
 
 /// Logging levels for AdmobSwiftUI
 public enum AdmobSwiftUILogLevel: Int {
+    /// No logging.
     case none = 0
+    /// Errors only.
     case error = 1
+    /// Errors and warnings.
     case warning = 2
+    /// Errors, warnings, and informational messages.
     case info = 3
+    /// Everything, including verbose debug messages.
     case debug = 4
 }
 

--- a/Sources/AdmobSwiftUI/Consent/ConsentManager.swift
+++ b/Sources/AdmobSwiftUI/Consent/ConsentManager.swift
@@ -55,9 +55,12 @@ public struct ConsentDebugSettings: Sendable, Equatable {
         case other
     }
 
+    /// Simulated geography for consent testing.
     public var geography: Geography
+    /// UMP hashed device IDs that should receive debug consent behavior.
     public var testDeviceIdentifiers: [String]
 
+    /// Creates debug settings.
     public init(geography: Geography = .disabled, testDeviceIdentifiers: [String] = []) {
         self.geography = geography
         self.testDeviceIdentifiers = testDeviceIdentifiers
@@ -93,7 +96,10 @@ public struct ConsentDebugSettings: Sendable, Equatable {
 @MainActor
 public final class ConsentManager: ObservableObject {
 
+    /// Shared instance backed by the real UMP SDK.
     public static let shared = ConsentManager()
+
+    private let service: any ConsentService
 
     /// The user's current consent status. Updated after every consent operation.
     @Published public private(set) var consentStatus: ConsentStatus = .unknown
@@ -101,17 +107,20 @@ public final class ConsentManager: ObservableObject {
     /// Whether ads can be requested. `true` once consent has been gathered
     /// (or determined unnecessary), including values persisted from a previous session.
     public var canRequestAds: Bool {
-        ConsentInformation.shared.canRequestAds
+        service.canRequestAds
     }
 
     /// Whether the app must offer the user an entry point (e.g. in Settings)
     /// to modify their privacy options.
     public var isPrivacyOptionsRequired: Bool {
-        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+        service.isPrivacyOptionsRequired
     }
 
-    private init() {
-        consentStatus = ConsentStatus(ConsentInformation.shared.consentStatus)
+    /// Internal so tests can inject a mock `ConsentService`;
+    /// production code always goes through `shared`.
+    init(service: any ConsentService = UMPConsentService()) {
+        self.service = service
+        consentStatus = service.consentStatus
     }
 
     /// Runs the full UMP consent flow: requests a consent info update, then
@@ -132,17 +141,14 @@ public final class ConsentManager: ObservableObject {
         debugSettings: ConsentDebugSettings? = nil,
         tagForUnderAgeOfConsent: Bool = false
     ) async throws {
-        let parameters = RequestParameters()
-        parameters.isTaggedForUnderAgeOfConsent = tagForUnderAgeOfConsent
-        if let debugSettings {
-            parameters.debugSettings = debugSettings.umpDebugSettings
-        }
-
         defer { syncStatus() }
         do {
-            try await ConsentInformation.shared.requestConsentInfoUpdate(with: parameters)
+            try await service.requestConsentInfoUpdate(
+                tagForUnderAgeOfConsent: tagForUnderAgeOfConsent,
+                debugSettings: debugSettings
+            )
             syncStatus()
-            try await ConsentForm.loadAndPresentIfRequired(from: viewController)
+            try await service.loadAndPresentConsentFormIfRequired(from: viewController)
             AdmobSwiftUI.log("Consent gathered. status=\(consentStatus), canRequestAds=\(canRequestAds)", level: .info)
         } catch {
             AdmobSwiftUI.log("Consent gathering failed: \(error.localizedDescription)", level: .error)
@@ -160,7 +166,7 @@ public final class ConsentManager: ObservableObject {
     public func presentPrivacyOptionsForm(from viewController: UIViewController? = nil) async throws {
         defer { syncStatus() }
         do {
-            try await ConsentForm.presentPrivacyOptionsForm(from: viewController)
+            try await service.presentPrivacyOptionsForm(from: viewController)
         } catch {
             AdmobSwiftUI.log("Privacy options form failed: \(error.localizedDescription)", level: .error)
             throw AdmobSwiftUIError.consentGatheringFailed(error)
@@ -183,11 +189,11 @@ public final class ConsentManager: ObservableObject {
     /// Clears all consent state from persistent storage. Intended for debugging
     /// and testing only — never call this in production flows.
     public func reset() {
-        ConsentInformation.shared.reset()
+        service.reset()
         syncStatus()
     }
 
     private func syncStatus() {
-        consentStatus = ConsentStatus(ConsentInformation.shared.consentStatus)
+        consentStatus = service.consentStatus
     }
 }

--- a/Sources/AdmobSwiftUI/Consent/ConsentService.swift
+++ b/Sources/AdmobSwiftUI/Consent/ConsentService.swift
@@ -1,0 +1,79 @@
+//
+//  ConsentService.swift
+//  AdmobSwiftUI
+//
+
+import Foundation
+import UIKit
+import UserMessagingPlatform
+
+/// Abstraction over the UMP SDK so `ConsentManager`'s state machine can be
+/// unit-tested with a mock. The package always uses `UMPConsentService`;
+/// tests inject their own implementation via `ConsentManager.init(service:)`.
+@MainActor
+protocol ConsentService: AnyObject {
+    /// Current consent status, already mapped to the package's `ConsentStatus`.
+    var consentStatus: ConsentStatus { get }
+
+    /// Whether ads can be requested under the current consent state.
+    var canRequestAds: Bool { get }
+
+    /// Whether a privacy-options entry point must be offered to the user.
+    var isPrivacyOptionsRequired: Bool { get }
+
+    /// Requests a consent info update from the consent provider.
+    func requestConsentInfoUpdate(
+        tagForUnderAgeOfConsent: Bool,
+        debugSettings: ConsentDebugSettings?
+    ) async throws
+
+    /// Loads and presents the consent form if the updated info requires one.
+    func loadAndPresentConsentFormIfRequired(from viewController: UIViewController?) async throws
+
+    /// Presents the privacy options form.
+    func presentPrivacyOptionsForm(from viewController: UIViewController?) async throws
+
+    /// Clears all persisted consent state.
+    func reset()
+}
+
+/// Production `ConsentService` backed by the real UMP SDK.
+@MainActor
+final class UMPConsentService: ConsentService {
+
+    var consentStatus: ConsentStatus {
+        ConsentStatus(ConsentInformation.shared.consentStatus)
+    }
+
+    var canRequestAds: Bool {
+        ConsentInformation.shared.canRequestAds
+    }
+
+    var isPrivacyOptionsRequired: Bool {
+        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+    }
+
+    func requestConsentInfoUpdate(
+        tagForUnderAgeOfConsent: Bool,
+        debugSettings: ConsentDebugSettings?
+    ) async throws {
+        let parameters = RequestParameters()
+        parameters.isTaggedForUnderAgeOfConsent = tagForUnderAgeOfConsent
+        if let debugSettings {
+            parameters.debugSettings = debugSettings.umpDebugSettings
+        }
+        try await ConsentInformation.shared.requestConsentInfoUpdate(with: parameters)
+    }
+
+    func loadAndPresentConsentFormIfRequired(from viewController: UIViewController?) async throws {
+        try await ConsentForm.loadAndPresentIfRequired(from: viewController)
+    }
+
+    func presentPrivacyOptionsForm(from viewController: UIViewController?) async throws {
+        try await ConsentForm.presentPrivacyOptionsForm(from: viewController)
+    }
+
+    func reset() {
+        ConsentInformation.shared.reset()
+    }
+}

--- a/Sources/AdmobSwiftUI/Fullscreen/AdViewControllerRepresentable.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/AdViewControllerRepresentable.swift
@@ -8,18 +8,24 @@
 import SwiftUI
 import GoogleMobileAds
 
-// MARK: - Helper to present Interstitial Ad
+/// Bridges a `UIViewController` into the SwiftUI view hierarchy so full-screen
+/// ad coordinators have something to present from.
+///
+/// Place it in a `.background` with a zero frame and pass its ``viewController``
+/// to the coordinator's `present(from:)`.
 public struct AdViewControllerRepresentable: UIViewControllerRepresentable {
+    /// The hosted view controller; pass it to a coordinator's `present(from:)`.
     public var viewController = UIViewController()
-    
+
+    /// Creates the representable with a fresh hosted view controller.
     public init() {
-        
+
     }
-    
+
     public func makeUIViewController(context: Context) -> some UIViewController {
         return viewController
     }
-    
+
     public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
 }
 

--- a/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/AppOpenAdCoordinator.swift
@@ -9,8 +9,15 @@
 import SwiftUI
 import UIKit
 
+/// Coordinator for App Open ads, conforming to ``FullScreenAdCoordinator``.
+///
+/// Loaded ads expire after 4 hours (Google policy); an expired ad reports
+/// `isReady == false` and `present(from:)` throws ``AdmobSwiftUIError/adExpired``.
+/// For the typical scene-phase flow, enable ``autoReloadsOnForeground`` and call
+/// ``presentIfAvailable(from:)`` when the app becomes active.
 @MainActor
 public final class AppOpenAdCoordinator: NSObject, ObservableObject, FullScreenAdCoordinator {
+    /// Current lifecycle state of the ad.
     @Published public private(set) var adState: AdState = .idle
 
     /// When enabled, the coordinator automatically reloads an ad after the
@@ -26,6 +33,9 @@ public final class AppOpenAdCoordinator: NSObject, ObservableObject, FullScreenA
     private var loadTime: Date?
     private var foregroundObserver: (any NSObjectProtocol)?
 
+    /// Creates a coordinator.
+    /// - Parameter adUnitID: The App Open ad unit ID. Defaults to the
+    ///   environment-appropriate ID from ``AdmobSwiftUI/AdUnitIDs``.
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.appOpen) {
         // Validate ad unit ID
         guard !adUnitID.isEmpty else {
@@ -48,10 +58,14 @@ public final class AppOpenAdCoordinator: NSObject, ObservableObject, FullScreenA
 
     // MARK: - FullScreenAdCoordinator
 
+    /// Whether an ad is loaded, unexpired, and can be presented right now.
     public var isReady: Bool {
         adState == .ready && !isAdExpired
     }
 
+    /// Loads an App Open ad, replacing any previously loaded one.
+    /// A call made while another load is in flight is ignored.
+    /// - Throws: ``AdmobSwiftUIError/adLoadFailed(_:)`` if the request fails.
     public func load() async throws {
         guard adState != .loading else {
             AdmobSwiftUI.log("App open ad is already loading, request ignored", level: .debug)
@@ -73,6 +87,9 @@ public final class AppOpenAdCoordinator: NSObject, ObservableObject, FullScreenA
         }
     }
 
+    /// Presents the loaded App Open ad.
+    /// - Throws: ``AdmobSwiftUIError/adNotLoaded`` if no ad is ready,
+    ///   ``AdmobSwiftUIError/adExpired`` if the loaded ad is older than 4 hours.
     public func present(from viewController: UIViewController) throws {
         guard let appOpenAd else {
             throw AdmobSwiftUIError.adNotLoaded
@@ -171,21 +188,25 @@ extension AppOpenAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
 
 // MARK: - Deprecated v2 API (will be removed in 4.0)
 extension AppOpenAdCoordinator {
+    /// Replaced by ``isReady``.
     @available(*, deprecated, renamed: "isReady", message: "Use `isReady` instead. Will be removed in 4.0.")
     public var isAdAvailable: Bool {
         isReady
     }
 
+    /// Fire-and-forget load. Replaced by `try await load()`.
     @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
     public func loadAd() {
         Task { try? await load() }
     }
 
+    /// Presents the loaded ad. Replaced by ``present(from:)``.
     @available(*, deprecated, renamed: "present(from:)", message: "Use `present(from:)` or `presentIfAvailable(from:)` instead. Will be removed in 4.0.")
     public func showAd(from viewController: UIViewController) throws {
         try present(from: viewController)
     }
 
+    /// Loads and returns the raw SDK ad object. Replaced by ``load()`` + ``present(from:)``.
     @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
     public func loadAppOpenAd() async throws -> GoogleMobileAds.AppOpenAd {
         try await load()
@@ -195,6 +216,7 @@ extension AppOpenAdCoordinator {
         return ad
     }
 
+    /// Loads and returns the raw SDK ad object. Replaced by ``load()`` + ``present(from:)``.
     @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
     public func loadAdAsync() async throws -> GoogleMobileAds.AppOpenAd {
         try await loadAppOpenAd()

--- a/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/InterstitialAdCoordinator.swift
@@ -8,13 +8,22 @@
 @preconcurrency import GoogleMobileAds
 import SwiftUI
 
+/// Coordinator for interstitial ads, conforming to ``FullScreenAdCoordinator``.
+///
+/// Load with `try await load()`, then present with `present(from:)` — or use
+/// `loadAndPresent(from:)` to do both. Include an ``AdViewControllerRepresentable``
+/// in the view hierarchy to obtain a presenting view controller.
 @MainActor
 public final class InterstitialAdCoordinator: NSObject, ObservableObject, FullScreenAdCoordinator {
+    /// Current lifecycle state of the ad.
     @Published public private(set) var adState: AdState = .idle
 
     private var interstitial: GoogleMobileAds.InterstitialAd?
     private let adUnitID: String
 
+    /// Creates a coordinator.
+    /// - Parameter adUnitID: The interstitial ad unit ID. Defaults to the
+    ///   environment-appropriate ID from ``AdmobSwiftUI/AdUnitIDs``.
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.interstitial) {
         self.adUnitID = adUnitID
         super.init()
@@ -22,6 +31,9 @@ public final class InterstitialAdCoordinator: NSObject, ObservableObject, FullSc
 
     // MARK: - FullScreenAdCoordinator
 
+    /// Loads an interstitial ad, replacing any previously loaded one.
+    /// A call made while another load is in flight is ignored.
+    /// - Throws: ``AdmobSwiftUIError/adLoadFailed(_:)`` if the request fails.
     public func load() async throws {
         guard adState != .loading else {
             AdmobSwiftUI.log("Interstitial ad is already loading, request ignored", level: .debug)
@@ -42,6 +54,8 @@ public final class InterstitialAdCoordinator: NSObject, ObservableObject, FullSc
         }
     }
 
+    /// Presents the loaded interstitial ad.
+    /// - Throws: ``AdmobSwiftUIError/adNotLoaded`` if no ad is ready.
     public func present(from viewController: UIViewController) throws {
         guard let interstitial else {
             throw AdmobSwiftUIError.adNotLoaded
@@ -80,16 +94,19 @@ extension InterstitialAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
 
 // MARK: - Deprecated v2 API (will be removed in 4.0)
 extension InterstitialAdCoordinator {
+    /// Fire-and-forget load. Replaced by `try await load()`.
     @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
     public func loadAd() {
         Task { try? await load() }
     }
 
+    /// Presents the loaded ad. Replaced by ``present(from:)``.
     @available(*, deprecated, renamed: "present(from:)", message: "Use `present(from:)` instead. Will be removed in 4.0.")
     public func showAd(from viewController: UIViewController) throws {
         try present(from: viewController)
     }
 
+    /// Loads and returns the raw SDK ad object. Replaced by ``load()`` + ``present(from:)``.
     @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
     public func loadInterstitialAd() async throws -> GoogleMobileAds.InterstitialAd {
         try await load()

--- a/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Fullscreen/RewardedAdCoordinator.swift
@@ -18,12 +18,16 @@ public final class RewardedAdCoordinator: NSObject, ObservableObject {
 
     /// Which rewarded format to load.
     public enum AdKind: Sendable {
+        /// A standard rewarded ad (user opts in to watch).
         case rewarded
+        /// A rewarded interstitial ad (shown at natural transitions).
         case rewardedInterstitial
     }
 
+    /// Current lifecycle state of the ad.
     @Published public private(set) var adState: AdState = .idle
 
+    /// Whether an ad is loaded and can be presented right now.
     public var isReady: Bool { adState == .ready }
 
     private var rewardedAd: GoogleMobileAds.RewardedAd?
@@ -32,6 +36,10 @@ public final class RewardedAdCoordinator: NSObject, ObservableObject {
     private let interstitialAdUnitID: String
     private var rewardContinuation: CheckedContinuation<AdReward, any Error>?
 
+    /// Creates a coordinator.
+    /// - Parameters:
+    ///   - adUnitID: Ad unit ID used for ``AdKind/rewarded`` loads.
+    ///   - interstitialAdUnitID: Ad unit ID used for ``AdKind/rewardedInterstitial`` loads.
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.rewarded,
                 interstitialAdUnitID: String = AdmobSwiftUI.AdUnitIDs.rewardedInterstitial) {
         self.adUnitID = adUnitID
@@ -40,6 +48,9 @@ public final class RewardedAdCoordinator: NSObject, ObservableObject {
 
     // MARK: - Async/await API
 
+    /// Loads an ad of the given kind, replacing any previously loaded one.
+    /// A call made while another load is in flight is ignored.
+    /// - Throws: ``AdmobSwiftUIError/adLoadFailed(_:)`` if the request fails.
     public func load(_ kind: AdKind = .rewarded) async throws {
         guard adState != .loading else {
             AdmobSwiftUI.log("Rewarded ad is already loading, request ignored", level: .debug)
@@ -147,16 +158,19 @@ extension RewardedAdCoordinator: GoogleMobileAds.FullScreenContentDelegate {
 
 // MARK: - Deprecated v2 API (will be removed in 4.0)
 extension RewardedAdCoordinator {
+    /// v2 initializer kept for source compatibility. Replaced by `init(adUnitID:interstitialAdUnitID:)`.
     @available(*, deprecated, renamed: "init(adUnitID:interstitialAdUnitID:)", message: "Use `init(adUnitID:interstitialAdUnitID:)` instead. Will be removed in 4.0.")
     public convenience init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.rewarded, InterstitialID: String) {
         self.init(adUnitID: adUnitID, interstitialAdUnitID: InterstitialID)
     }
 
+    /// Fire-and-forget load. Replaced by `try await load(_:)`.
     @available(*, deprecated, renamed: "load(_:)", message: "Use `try await load()` instead. Will be removed in 4.0.")
     public func loadAd() {
         Task { try? await load() }
     }
 
+    /// Loads and returns the raw SDK ad object. Replaced by ``load(_:)`` + ``present(from:)``.
     @available(*, deprecated, message: "Use `load()` and `present(from:)` instead. Will be removed in 4.0.")
     public func loadRewardedAd() async throws -> GoogleMobileAds.RewardedAd {
         try await load(.rewarded)
@@ -166,6 +180,7 @@ extension RewardedAdCoordinator {
         return ad
     }
 
+    /// Loads and returns the raw SDK ad object. Replaced by ``load(_:)`` + ``present(from:)``.
     @available(*, deprecated, message: "Use `load(.rewardedInterstitial)` and `present(from:)` instead. Will be removed in 4.0.")
     public func loadInterstitialAd() async throws -> GoogleMobileAds.RewardedInterstitialAd {
         try await load(.rewardedInterstitial)
@@ -175,6 +190,7 @@ extension RewardedAdCoordinator {
         return ad
     }
 
+    /// Callback-based presentation. Replaced by `try await present(from:)`, which returns the ``AdReward``.
     @available(*, deprecated, message: "Use `try await present(from:)` instead. Will be removed in 4.0.")
     public func showAd(from viewController: UIViewController, userDidEarnRewardHandler completion: @escaping (Int) -> Void) {
         guard let rewardedAd else {

--- a/Sources/AdmobSwiftUI/Native/AdCache.swift
+++ b/Sources/AdmobSwiftUI/Native/AdCache.swift
@@ -1,0 +1,64 @@
+//
+//  AdCache.swift
+//  AdmobSwiftUI
+//
+
+import Foundation
+
+/// In-memory cache keyed by ad unit ID, with a size cap and request-time
+/// tracking for throttling. Backs `NativeAdViewModel`'s shared native ad cache;
+/// generic over `Value` so tests don't need real SDK ad objects.
+@MainActor
+final class AdCache<Value> {
+
+    /// Maximum number of values kept; storing beyond this evicts the entry
+    /// with the oldest request time.
+    let maxSize: Int
+
+    private var values: [String: Value] = [:]
+    private var lastRequestTimes: [String: Date] = [:]
+
+    init(maxSize: Int) {
+        self.maxSize = max(1, maxSize)
+    }
+
+    var count: Int { values.count }
+
+    func value(for key: String) -> Value? {
+        values[key]
+    }
+
+    func lastRequestTime(for key: String) -> Date? {
+        lastRequestTimes[key]
+    }
+
+    /// Records that a request for `key` started, so throttling also covers
+    /// in-flight and failed requests, not just successful ones.
+    func markRequested(_ key: String, at date: Date = Date()) {
+        lastRequestTimes[key] = date
+    }
+
+    /// `true` while a cached value exists and the last request for `key`
+    /// is younger than `interval` — i.e. a new request should be skipped.
+    func hasFreshValue(for key: String, within interval: TimeInterval, now: Date = Date()) -> Bool {
+        guard values[key] != nil, let lastRequest = lastRequestTimes[key] else { return false }
+        return now.timeIntervalSince(lastRequest) < interval
+    }
+
+    func store(_ value: Value, for key: String, at date: Date = Date()) {
+        evictOldestIfNeeded(insertingKey: key)
+        values[key] = value
+        lastRequestTimes[key] = date
+    }
+
+    private func evictOldestIfNeeded(insertingKey key: String) {
+        guard values[key] == nil, values.count >= maxSize else { return }
+        let oldestKey = values.keys.min {
+            (lastRequestTimes[$0] ?? .distantPast) < (lastRequestTimes[$1] ?? .distantPast)
+        }
+        if let oldestKey {
+            values.removeValue(forKey: oldestKey)
+            lastRequestTimes.removeValue(forKey: oldestKey)
+        }
+    }
+}

--- a/Sources/AdmobSwiftUI/Native/NativeAdAssets.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdAssets.swift
@@ -5,14 +5,23 @@ import SwiftUI
 /// registered on the underlying `GADNativeAdView` so the SDK attributes
 /// clicks on them.
 public enum NativeAdAssetKind: CaseIterable, Sendable {
+    /// The ad headline. Google requires it to be displayed.
     case headline
+    /// The call-to-action text (e.g. "Install").
     case callToAction
+    /// The advertiser's icon image.
     case icon
+    /// The ad body text.
     case body
+    /// The app store name (app-install ads).
     case store
+    /// The price string (app-install ads).
     case price
+    /// A large ad image.
     case image
+    /// The app's star rating (app-install ads).
     case starRating
+    /// The advertiser name.
     case advertiser
 }
 
@@ -221,6 +230,7 @@ public struct AdBadge: View {
     let backgroundColor: Color
     let cornerRadius: CGFloat
 
+    /// Creates a badge with the given colors and corner radius.
     public init(foregroundColor: Color = .white,
                 backgroundColor: Color = .orange,
                 cornerRadius: CGFloat = 2) {

--- a/Sources/AdmobSwiftUI/Native/NativeAdContainer.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdContainer.swift
@@ -25,6 +25,10 @@ public struct AdmobNativeAdContainer<Content: View>: View {
     private let ad: GoogleMobileAds.NativeAd
     private let content: (NativeAdAssets) -> Content
 
+    /// Creates the container.
+    /// - Parameters:
+    ///   - ad: The loaded native ad to render.
+    ///   - content: Builds the SwiftUI layout from the ad's ``NativeAdAssets``.
     public init(ad: GoogleMobileAds.NativeAd,
                 @ViewBuilder content: @escaping (NativeAdAssets) -> Content) {
         self.ad = ad

--- a/Sources/AdmobSwiftUI/Native/NativeAdView.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdView.swift
@@ -10,6 +10,10 @@ public struct NativeAdView: View {
     @ObservedObject var nativeViewModel: NativeAdViewModel
     var style: NativeAdViewStyle
 
+    /// Creates the view.
+    /// - Parameters:
+    ///   - nativeViewModel: View model that loads and publishes the native ad.
+    ///   - style: Which built-in template to render.
     public init(nativeViewModel: NativeAdViewModel, style: NativeAdViewStyle = .basic) {
         self.nativeViewModel = nativeViewModel
         self.style = style

--- a/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdViewModel.swift
@@ -8,28 +8,38 @@
 import SwiftUI
 @preconcurrency import GoogleMobileAds
 
+/// Loads native ads and publishes them for ``NativeAdView`` /
+/// ``AdmobNativeAdContainer``. Loaded ads are cached per ad unit ID and shared
+/// across view model instances, with requests throttled by ``requestInterval``.
 @MainActor
 public class NativeAdViewModel: NSObject, ObservableObject {
+    /// The most recently loaded (or cached) native ad; `nil` until a load succeeds.
     @Published public var nativeAd: GoogleMobileAds.NativeAd?
+    /// Whether an ad request is currently in flight.
     @Published public var isLoading: Bool = false
     private var adLoader: GoogleMobileAds.AdLoader!
     private var adUnitID: String
-    private var lastRequestTime: Date?
     private var loadContinuation: CheckedContinuation<Void, any Error>?
+    /// Minimum interval (seconds) between ad requests for the same ad unit;
+    /// `load()` calls inside the window return the cached ad instead.
     public var requestInterval: Int
-    private static let maxCacheSize = AdmobSwiftUI.Constants.nativeAdCacheMaxSize
-    // Cache is isolated to the main actor along with the rest of the class.
-    private static var cachedAds: [String: GoogleMobileAds.NativeAd] = [:]
-    private static var lastRequestTimes: [String: Date] = [:]
+    // Shared across view model instances; isolated to the main actor.
+    private static let cache = AdCache<GoogleMobileAds.NativeAd>(
+        maxSize: AdmobSwiftUI.Constants.nativeAdCacheMaxSize
+    )
 
+    /// Creates a view model, picking up any cached ad for the ad unit.
+    /// - Parameters:
+    ///   - adUnitID: The native ad unit ID. Defaults to the
+    ///     environment-appropriate ID from ``AdmobSwiftUI/AdUnitIDs``.
+    ///   - requestInterval: Minimum interval (seconds) between requests.
     public init(adUnitID: String = AdmobSwiftUI.AdUnitIDs.native,
                 requestInterval: Int = AdmobSwiftUI.Constants.nativeAdDefaultRequestInterval) {
         self.adUnitID = adUnitID
         self.requestInterval = requestInterval
         super.init()
 
-        self.nativeAd = NativeAdViewModel.cachedAds[adUnitID]
-        self.lastRequestTime = NativeAdViewModel.lastRequestTimes[adUnitID]
+        self.nativeAd = Self.cache.value(for: adUnitID)
     }
 
     /// Loads a native ad and suspends until the request finishes.
@@ -41,8 +51,9 @@ public class NativeAdViewModel: NSObject, ObservableObject {
     public func load() async throws {
         let now = Date()
 
-        if nativeAd != nil, let lastRequest = lastRequestTime, now.timeIntervalSince(lastRequest) < Double(requestInterval) {
-            AdmobSwiftUI.log("The last request was made less than \(requestInterval / 60) minutes ago. New request is canceled.", level: .debug)
+        if Self.cache.hasFreshValue(for: adUnitID, within: TimeInterval(requestInterval), now: now) {
+            AdmobSwiftUI.log("The last request was made less than \(requestInterval) seconds ago. New request is canceled.", level: .debug)
+            nativeAd = Self.cache.value(for: adUnitID)
             return
         }
 
@@ -52,8 +63,7 @@ public class NativeAdViewModel: NSObject, ObservableObject {
         }
 
         isLoading = true
-        lastRequestTime = now
-        NativeAdViewModel.lastRequestTimes[adUnitID] = now
+        Self.cache.markRequested(adUnitID, at: now)
 
         let adViewOptions = GoogleMobileAds.NativeAdViewAdOptions()
         adViewOptions.preferredAdChoicesPosition = .topRightCorner
@@ -73,8 +83,7 @@ public class NativeAdViewModel: NSObject, ObservableObject {
         nativeAd.delegate = self
         self.isLoading = false
 
-        // Cache the ad safely with size management
-        Self.setCachedAd(nativeAd, for: adUnitID)
+        Self.cache.store(nativeAd, for: adUnitID)
         nativeAd.mediaContent.videoController.delegate = self
 
         loadContinuation?.resume()
@@ -86,29 +95,11 @@ public class NativeAdViewModel: NSObject, ObservableObject {
         loadContinuation?.resume(throwing: AdmobSwiftUIError.adLoadFailed(error))
         loadContinuation = nil
     }
-
-    // MARK: - Cache Management
-    private static func setCachedAd(_ ad: GoogleMobileAds.NativeAd, for key: String) {
-        // Clean cache if it's getting too large
-        cleanupCacheIfNeeded()
-
-        cachedAds[key] = ad
-        lastRequestTimes[key] = Date()
-    }
-
-    private static func cleanupCacheIfNeeded() {
-        guard cachedAds.count >= maxCacheSize else { return }
-
-        // Remove oldest cached ad
-        if let oldestKey = lastRequestTimes.min(by: { $0.value < $1.value })?.key {
-            cachedAds.removeValue(forKey: oldestKey)
-            lastRequestTimes.removeValue(forKey: oldestKey)
-        }
-    }
 }
 
 // MARK: - Deprecated v2 API (will be removed in 4.0)
 extension NativeAdViewModel {
+    /// Fire-and-forget load. Replaced by `try await load()`.
     @available(*, deprecated, renamed: "load()", message: "Use `try await load()` instead. Will be removed in 4.0.")
     public func refreshAd() {
         Task { try? await load() }

--- a/Sources/AdmobSwiftUI/Protocols/FullScreenAdCoordinator.swift
+++ b/Sources/AdmobSwiftUI/Protocols/FullScreenAdCoordinator.swift
@@ -22,9 +22,12 @@ public enum AdState: Sendable, Equatable {
 
 /// Reward earned from a rewarded ad.
 public struct AdReward: Sendable, Equatable {
+    /// Reward amount, as configured for the ad unit.
     public let amount: Int
+    /// Reward type (e.g. "coins"), as configured for the ad unit.
     public let type: String
 
+    /// Creates a reward value.
     public init(amount: Int, type: String) {
         self.amount = amount
         self.type = type

--- a/Tests/AdmobSwiftUITests/AdCacheTests.swift
+++ b/Tests/AdmobSwiftUITests/AdCacheTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import AdmobSwiftUI
+
+@MainActor
+final class AdCacheTests: XCTestCase {
+
+    private let baseDate = Date(timeIntervalSince1970: 1_000_000)
+
+    func testStoreAndRetrieve() throws {
+        let cache = AdCache<String>(maxSize: 3)
+        XCTAssertNil(cache.value(for: "a"))
+
+        cache.store("ad-a", for: "a", at: baseDate)
+
+        XCTAssertEqual(cache.value(for: "a"), "ad-a")
+        XCTAssertEqual(cache.lastRequestTime(for: "a"), baseDate)
+        XCTAssertEqual(cache.count, 1)
+    }
+
+    func testMaxSizeEvictsOldestEntry() throws {
+        let cache = AdCache<String>(maxSize: 3)
+        cache.store("ad-a", for: "a", at: baseDate)
+        cache.store("ad-b", for: "b", at: baseDate.addingTimeInterval(10))
+        cache.store("ad-c", for: "c", at: baseDate.addingTimeInterval(20))
+
+        cache.store("ad-d", for: "d", at: baseDate.addingTimeInterval(30))
+
+        XCTAssertEqual(cache.count, 3)
+        XCTAssertNil(cache.value(for: "a"), "Oldest entry must be evicted")
+        XCTAssertNil(cache.lastRequestTime(for: "a"))
+        XCTAssertEqual(cache.value(for: "d"), "ad-d")
+    }
+
+    func testRestoringExistingKeyDoesNotEvict() throws {
+        let cache = AdCache<String>(maxSize: 2)
+        cache.store("ad-a", for: "a", at: baseDate)
+        cache.store("ad-b", for: "b", at: baseDate.addingTimeInterval(10))
+
+        // Refreshing "a" replaces in place; "b" must survive.
+        cache.store("ad-a2", for: "a", at: baseDate.addingTimeInterval(20))
+
+        XCTAssertEqual(cache.count, 2)
+        XCTAssertEqual(cache.value(for: "a"), "ad-a2")
+        XCTAssertEqual(cache.value(for: "b"), "ad-b")
+    }
+
+    func testHasFreshValueWithinInterval() throws {
+        let cache = AdCache<String>(maxSize: 3)
+        cache.store("ad-a", for: "a", at: baseDate)
+
+        XCTAssertTrue(cache.hasFreshValue(for: "a", within: 60, now: baseDate.addingTimeInterval(59)))
+        XCTAssertFalse(
+            cache.hasFreshValue(for: "a", within: 60, now: baseDate.addingTimeInterval(60)),
+            "Value is stale once the full interval has elapsed"
+        )
+    }
+
+    func testHasFreshValueRequiresAStoredValue() throws {
+        let cache = AdCache<String>(maxSize: 3)
+
+        XCTAssertFalse(cache.hasFreshValue(for: "a", within: 60, now: baseDate))
+
+        // A request that never completed leaves a timestamp but no value:
+        // freshness must be false so the next load() retries.
+        cache.markRequested("a", at: baseDate)
+        XCTAssertFalse(cache.hasFreshValue(for: "a", within: 60, now: baseDate.addingTimeInterval(1)))
+        XCTAssertEqual(cache.lastRequestTime(for: "a"), baseDate)
+    }
+
+    func testMarkRequestedRefreshesThrottleWindow() throws {
+        let cache = AdCache<String>(maxSize: 3)
+        cache.store("ad-a", for: "a", at: baseDate)
+
+        // A later (failed or in-flight) request moves the throttle window forward.
+        cache.markRequested("a", at: baseDate.addingTimeInterval(100))
+
+        XCTAssertTrue(cache.hasFreshValue(for: "a", within: 60, now: baseDate.addingTimeInterval(120)))
+    }
+
+    func testMaxSizeIsClampedToAtLeastOne() throws {
+        let cache = AdCache<String>(maxSize: 0)
+        cache.store("ad-a", for: "a", at: baseDate)
+
+        XCTAssertEqual(cache.maxSize, 1)
+        XCTAssertEqual(cache.count, 1)
+
+        cache.store("ad-b", for: "b", at: baseDate.addingTimeInterval(10))
+        XCTAssertEqual(cache.count, 1)
+        XCTAssertEqual(cache.value(for: "b"), "ad-b")
+    }
+}

--- a/Tests/AdmobSwiftUITests/ConsentManagerTests.swift
+++ b/Tests/AdmobSwiftUITests/ConsentManagerTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import UIKit
+@testable import AdmobSwiftUI
+
+// MARK: - Mock
+
+@MainActor
+private final class MockConsentService: ConsentService {
+    var consentStatus: ConsentStatus = .unknown
+    var canRequestAds = false
+    var isPrivacyOptionsRequired = false
+
+    /// Status the mock transitions to after a successful info update / form presentation,
+    /// simulating UMP's state machine.
+    var statusAfterInfoUpdate: ConsentStatus?
+    var statusAfterFormPresentation: ConsentStatus?
+
+    var infoUpdateError: (any Error)?
+    var formError: (any Error)?
+    var privacyOptionsError: (any Error)?
+
+    private(set) var infoUpdateCalls: [(tagForUnderAgeOfConsent: Bool, debugSettings: ConsentDebugSettings?)] = []
+    private(set) var formPresentationCount = 0
+    private(set) var privacyOptionsCount = 0
+    private(set) var resetCount = 0
+
+    func requestConsentInfoUpdate(
+        tagForUnderAgeOfConsent: Bool,
+        debugSettings: ConsentDebugSettings?
+    ) async throws {
+        infoUpdateCalls.append((tagForUnderAgeOfConsent, debugSettings))
+        if let infoUpdateError { throw infoUpdateError }
+        if let statusAfterInfoUpdate { consentStatus = statusAfterInfoUpdate }
+    }
+
+    func loadAndPresentConsentFormIfRequired(from viewController: UIViewController?) async throws {
+        formPresentationCount += 1
+        if let formError { throw formError }
+        if let statusAfterFormPresentation {
+            consentStatus = statusAfterFormPresentation
+            canRequestAds = true
+        }
+    }
+
+    func presentPrivacyOptionsForm(from viewController: UIViewController?) async throws {
+        privacyOptionsCount += 1
+        if let privacyOptionsError { throw privacyOptionsError }
+    }
+
+    func reset() {
+        resetCount += 1
+        consentStatus = .unknown
+        canRequestAds = false
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class ConsentManagerTests: XCTestCase {
+
+    private var service: MockConsentService!
+    private var manager: ConsentManager!
+
+    override func setUp() async throws {
+        service = MockConsentService()
+        manager = ConsentManager(service: service)
+    }
+
+    func testInitReadsStatusFromService() throws {
+        service.consentStatus = .obtained
+        let manager = ConsentManager(service: service)
+        XCTAssertEqual(manager.consentStatus, .obtained)
+    }
+
+    func testGatherConsentRunsUpdateThenFormAndSyncsStatus() async throws {
+        service.statusAfterInfoUpdate = .required
+        service.statusAfterFormPresentation = .obtained
+
+        try await manager.gatherConsent()
+
+        XCTAssertEqual(service.infoUpdateCalls.count, 1)
+        XCTAssertEqual(service.formPresentationCount, 1)
+        XCTAssertEqual(manager.consentStatus, .obtained)
+        XCTAssertTrue(manager.canRequestAds)
+    }
+
+    func testGatherConsentForwardsParameters() async throws {
+        let debugSettings = ConsentDebugSettings(geography: .eea, testDeviceIdentifiers: ["abc"])
+        try await manager.gatherConsent(debugSettings: debugSettings, tagForUnderAgeOfConsent: true)
+
+        XCTAssertEqual(service.infoUpdateCalls.count, 1)
+        XCTAssertTrue(service.infoUpdateCalls[0].tagForUnderAgeOfConsent)
+        XCTAssertEqual(service.infoUpdateCalls[0].debugSettings, debugSettings)
+    }
+
+    func testGatherConsentInfoUpdateFailureThrowsAndStillSyncsStatus() async throws {
+        service.infoUpdateError = NSError(domain: "ump", code: 1)
+        // Simulate UMP having a persisted status even though the update failed.
+        service.consentStatus = .obtained
+
+        do {
+            try await manager.gatherConsent()
+            XCTFail("Expected gatherConsent to throw")
+        } catch {
+            guard case AdmobSwiftUIError.consentGatheringFailed = error else {
+                return XCTFail("Expected consentGatheringFailed, got \(error)")
+            }
+        }
+        XCTAssertEqual(service.formPresentationCount, 0, "Form must not be presented when the info update fails")
+        XCTAssertEqual(manager.consentStatus, .obtained, "Status must sync even on failure")
+    }
+
+    func testGatherConsentFormFailureThrowsConsentGatheringFailed() async throws {
+        service.statusAfterInfoUpdate = .required
+        service.formError = NSError(domain: "ump", code: 2)
+
+        do {
+            try await manager.gatherConsent()
+            XCTFail("Expected gatherConsent to throw")
+        } catch {
+            guard case AdmobSwiftUIError.consentGatheringFailed = error else {
+                return XCTFail("Expected consentGatheringFailed, got \(error)")
+            }
+        }
+        XCTAssertEqual(manager.consentStatus, .required, "Status from the successful info update must be kept")
+    }
+
+    func testPresentPrivacyOptionsFormCallsServiceAndSyncs() async throws {
+        service.statusAfterInfoUpdate = nil
+        service.consentStatus = .obtained
+
+        try await manager.presentPrivacyOptionsForm()
+
+        XCTAssertEqual(service.privacyOptionsCount, 1)
+        XCTAssertEqual(manager.consentStatus, .obtained)
+    }
+
+    func testPresentPrivacyOptionsFormFailureWrapsError() async throws {
+        service.privacyOptionsError = NSError(domain: "ump", code: 3)
+
+        do {
+            try await manager.presentPrivacyOptionsForm()
+            XCTFail("Expected presentPrivacyOptionsForm to throw")
+        } catch {
+            guard case AdmobSwiftUIError.consentGatheringFailed = error else {
+                return XCTFail("Expected consentGatheringFailed, got \(error)")
+            }
+        }
+    }
+
+    func testResetClearsStatus() async throws {
+        service.statusAfterInfoUpdate = .required
+        service.statusAfterFormPresentation = .obtained
+        try await manager.gatherConsent()
+        XCTAssertEqual(manager.consentStatus, .obtained)
+
+        manager.reset()
+
+        XCTAssertEqual(service.resetCount, 1)
+        XCTAssertEqual(manager.consentStatus, .unknown)
+        XCTAssertFalse(manager.canRequestAds)
+    }
+
+    func testPassthroughProperties() throws {
+        XCTAssertFalse(manager.canRequestAds)
+        XCTAssertFalse(manager.isPrivacyOptionsRequired)
+
+        service.canRequestAds = true
+        service.isPrivacyOptionsRequired = true
+
+        XCTAssertTrue(manager.canRequestAds)
+        XCTAssertTrue(manager.isPrivacyOptionsRequired)
+    }
+}


### PR DESCRIPTION
Closes #16

## What's changed

### Swift 6 language mode
- `Package.swift` switches both targets to `swiftLanguageMode(.v6)` (was Swift 5 + StrictConcurrency warnings). Compiles with zero errors and zero warnings — the concurrency groundwork from #11/#12 paid off.

### Testability refactors
- **`ConsentService` protocol** (internal): abstracts UMP (`ConsentInformation` / `ConsentForm`) behind a protocol. Production path is unchanged (`ConsentManager.shared` → `UMPConsentService`); tests inject a mock via the internal `init(service:)`.
- **`AdCache<Value>`** (internal): extracts `NativeAdViewModel`'s static dictionaries into a dedicated main-actor cache with size cap, request-time throttling, and oldest-entry eviction. Fixes two latent edge cases: re-storing an existing key no longer evicts another entry, and eviction now always frees an actual cached value (previously it could remove only a dangling timestamp).

### Tests: 36 → 52, all green
- `ConsentManagerTests` (9): full state machine via mock — gather success/failure paths, status sync on failure (defer), form-not-presented-after-update-failure, privacy options, reset, passthroughs.
- `AdCacheTests` (7): store/retrieve, max-size eviction order, re-store behavior, freshness window boundary, failed-request throttling, maxSize clamp.

### CI (GitHub Actions)
- `.github/workflows/ci.yml`: macos-15 runner, two jobs — package tests via `xcodebuild test` on iOS Simulator (`swift test` doesn't work: GoogleMobileAds is an iOS-only binary), and demo app build. Runs on every PR and on pushes to `main` / `release/*`.

### DocC
- Doc comments for all public API: coordinators (incl. deprecated v2 shims), `AdmobSwiftUIError` cases, `Configuration` properties, log levels, `AdReward`, `AdViewControllerRepresentable`, native ad asset kinds.

## Verification
- `xcodebuild test` (iPhone 17 simulator): 52 tests, 0 failures
- `xcodebuild build` Demo: succeeds; only expected deprecation warnings in the Legacy demo page
- Package sources: zero warnings under Swift 6 mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)