### PR TITLE
fix(native): hug content height instead of adopting concrete height proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-06-12
+
+### Fixed
+
+- **Native ads no longer stretch to fill a concrete height proposal.** `NativeAdView` / `AdmobNativeAdContainer` adopted the parent's proposed height in `sizeThatFits`, so placing the ad directly in a `VStack` (outside a `List`/`ScrollView`) stretched it over the leftover screen space with the content floating in the middle. The view now always hugs its content height for the proposed width, matching the "automatic height" behaviour documented in MIGRATION.md and making sizing consistent across containers.
+
 ## [3.0.0] - 2026-06-11
 
 A major release: Google Mobile Ads SDK 13, Swift 6 language mode, a unified async/await API, UMP consent management, pure-SwiftUI native ads, and self-sizing banners. See [MIGRATION.md](MIGRATION.md) for upgrade paths from 2.x and 1.x.

--- a/Demo/AdmobSwitUIDemo/ContentView.swift
+++ b/Demo/AdmobSwitUIDemo/ContentView.swift
@@ -93,6 +93,10 @@ struct ContentView: View {
                         NativeAdStylesView()
                     }
 
+                    NavigationLink("Native Ad in VStack (sizing repro)") {
+                        NativeAdVStackSizingView()
+                    }
+
                     NavigationLink("Legacy v2 API (deprecated)") {
                         LegacyAPIView()
                     }

--- a/Demo/AdmobSwitUIDemo/NativeAdStylesView.swift
+++ b/Demo/AdmobSwitUIDemo/NativeAdStylesView.swift
@@ -120,6 +120,35 @@ struct NativeAdStylesView: View {
     }
 }
 
+/// 3.0.0 sizing bug 的回歸場景：廣告直放在 VStack（ScrollView 之外），
+/// 父容器會提案剩餘螢幕高度——廣告必須維持內容高度，不能被撐滿。
+struct NativeAdVStackSizingView: View {
+    @StateObject private var nativeViewModel = NativeAdViewModel(requestInterval: 60)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            NativeAdView(nativeViewModel: nativeViewModel, style: .largeBanner)
+                .background(Color(UIColor.secondarySystemBackground))
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(0..<30, id: \.self) { i in
+                        Text("Content row \(i)")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Divider()
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("VStack sizing")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            try? await nativeViewModel.load()
+        }
+    }
+}
+
 #Preview {
     NavigationStack {
         NativeAdStylesView()

--- a/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
+++ b/Sources/AdmobSwiftUI/AdmobSwiftUI.swift
@@ -6,7 +6,7 @@ import GoogleMobileAds
 public struct AdmobSwiftUI {
     
     /// Package version
-    public static let version = "3.0.0"
+    public static let version = "3.0.1"
 
     /// Constants shared across the package
     public enum Constants {

--- a/Sources/AdmobSwiftUI/Native/NativeAdContainer.swift
+++ b/Sources/AdmobSwiftUI/Native/NativeAdContainer.swift
@@ -164,11 +164,15 @@ struct NativeAdHostingView<Content: View>: UIViewRepresentable {
                       uiView: GoogleMobileAds.NativeAdView,
                       context: Context) -> CGSize? {
         guard let host = context.coordinator.hostingController else { return nil }
+        // Height always hugs the content for the proposed width. Adopting a
+        // concrete height proposal would stretch the ad to fill containers
+        // that distribute leftover space (e.g. a plain VStack), while nil
+        // proposals (List rows, ScrollView) already hugged — the same view
+        // must size consistently in both.
         let target = CGSize(width: proposal.width ?? UIView.layoutFittingExpandedSize.width,
-                            height: proposal.height ?? UIView.layoutFittingExpandedSize.height)
+                            height: UIView.layoutFittingExpandedSize.height)
         var size = host.sizeThatFits(in: target)
         if let width = proposal.width { size.width = width }
-        if let height = proposal.height { size.height = height }
         return size
     }
 


### PR DESCRIPTION
## 問題

`NativeAdView` / `AdmobNativeAdContainer` 在父容器提案**具體高度**時會照單全收（`NativeAdHostingView.sizeThatFits` 的 `if let height = proposal.height { size.height = height }`）。直放在 `VStack`（ScrollView 之外）時，VStack 把剩餘螢幕高度全提案給廣告 → 廣告撐滿大半螢幕、模板內容垂直置中上下大片留白。

`List` row / `ScrollView`（提案 nil）則正常量內容——同一個 view 在不同容器行為不一致，也違反 MIGRATION.md「高度自動」的承諾。

實例：MyFund 升 3.0.0 後三個 VStack 直放的畫面全部炸版（已先用 `.fixedSize(horizontal: false, vertical: true)` workaround）。

## 修法

高度永遠以「提案寬度下的內容 fitting 高度」為準（hug content），只採用寬度提案（fill width）。

## 驗證

- 套件測試 52/52 過（xcodebuild test, iOS Simulator）
- Demo 新增「Native Ad in VStack (sizing repro)」回歸場景：修復後 `.largeBanner` 緊貼內容高度（~110pt），下方內容立即可見
- 原本正常的 ScrollView 場景（Native Ad Styles 四種模板）行為不變，`.banner` / `.card` 截圖目視通過

版號 bump 3.0.1，CHANGELOG 已更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)